### PR TITLE
Retrieve the version file from the working directory

### DIFF
--- a/src/routes/dockerflow.js
+++ b/src/routes/dockerflow.js
@@ -8,7 +8,6 @@
 
 import Router from '@koa/router';
 import fs from 'fs';
-import path from 'path';
 
 export function dockerFlowRoutes() {
   const router = new Router();
@@ -18,21 +17,18 @@ export function dockerFlowRoutes() {
   // time in CircleCI and lives in dist/version.json.
   // We serve it directly if present, otherwise returns a 404.
   router.get('/__version__', async ctx => {
-    // We use path.join with __dirname so that the path doesn't depend on the
-    // current working directory.
-    // And we prefer it over require.resolve or path.resolve because they're not
-    // easy to mock in tests (maybe impossible). Also path.join does no
-    // filesystem access so it's probably faster than them.
-    const fileName = path.join(__dirname, '../../dist/version.json');
-
+    // We try to get the version file in the current working directory.
+    const versionFilePath = 'version.json';
     try {
-      const content = await fs.promises.readFile(fileName);
+      const content = await fs.promises.readFile(versionFilePath);
       ctx.body = content;
       ctx.type = 'json';
     } catch (e) {
       if (e.code === 'ENOENT') {
         // ENOENT means "No such file or directory"
-        throw new Error('The version file could not be found.');
+        throw new Error(
+          `The version file (${versionFilePath}) could not be found.`
+        );
       }
 
       // Rethrow the error otherwise.

--- a/test/api/dockerflow.test.js
+++ b/test/api/dockerflow.test.js
@@ -35,6 +35,7 @@ describe('dockerflow endpoints', () => {
     const agent = setup();
     await agent.get('/__version__').expect(500);
 
+    expect(fs.promises.readFile).toHaveBeenCalledWith('version.json');
     expect(process.stdout.write).toHaveBeenCalled();
   });
 
@@ -47,6 +48,7 @@ describe('dockerflow endpoints', () => {
       .expect('Content-Type', /^application\/json/)
       .expect(200);
 
+    expect(fs.promises.readFile).toHaveBeenCalledWith('version.json');
     expect(response.body).toEqual(fixture);
   });
 });


### PR DESCRIPTION
This changes how version.json is retrieved. Now we take it from the current working directory, which makes the app easier to deploy because it doesn't depend on specific directories anymore. This follows the suggestion of @leplatrem in https://github.com/firefox-devtools/profiler-server/pull/10#discussion_r337948742.

I decided to hardcode the value instead of making it configurable for simplicity, and also a bit for security -- I was being a bit paranoid in making it possible to point to any file and serve it.