### PR TITLE
Improve the logging mechanism

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,7 +6,7 @@
 import Koa from 'koa';
 
 import { config } from './config';
-import { getLogger } from './log';
+import { getLogger, logLevel } from './log';
 import { routes } from './routes';
 
 const log = getLogger('app');
@@ -19,9 +19,11 @@ export function createApp() {
     log.error('server_error', { error: err, stack: err.stack });
   });
 
-  if (config.env === 'development') {
+  if (config.env === 'development' || logLevel === 'verbose') {
     // For now we use this logger only for development because it's a bit
-    // costly. In production we should be able to have the logs of requests from
+    // costly. It's disabled in tests but can be enabled when configuring the
+    // environment variable LOG_LEVEL to "verbose".
+    // In production we should be able to have the logs of requests from
     // the server frontend instead.
     app.use(require('koa-logger')());
   }

--- a/src/log.js
+++ b/src/log.js
@@ -7,13 +7,51 @@
 
 import mozlog from 'mozlog';
 
-import { config } from './config';
+type LowerCasedLogLevel =
+  | 'trace' //     This will gather a stack automatically.
+  | 'verbose' //   This is displayed only when run with LOG_LEVEL=verbose
+  | 'debug' //     This is displayed in test and development environments.
+  | 'info' //      This is displayed in production too.
+  | 'warn' //      This is for messages more important than info but that aren't errors.
+  | 'error' //     This is for non-fatal errors.
+  | 'critical'; // This is for fatal errors.
 
-const isProduction = config.env === 'production';
+function toValidLogLevel(logLevel: ?string) {
+  if (!logLevel) {
+    return null;
+  }
+
+  const lowerCasedLogLevel = logLevel.toLowerCase();
+  switch (lowerCasedLogLevel) {
+    case 'trace':
+    case 'verbose':
+    case 'debug':
+    case 'info':
+    case 'warn':
+    case 'error':
+    case 'critical':
+      return lowerCasedLogLevel;
+    default:
+      return null;
+  }
+}
+
+// Note we don't use `config` because we want `config` to be able to log using
+// this file, and we want to avoid cycles in dependencies.
+const isProduction = process.env.NODE_ENV === 'production';
+
+// We can configure the log level from an environment variable LOG_LEVEL, but by
+// default this is 'debug' in development and test, and 'info' in production.
+const logLevelFromEnvironment = toValidLogLevel(process.env.LOG_LEVEL);
+export const logLevel: LowerCasedLogLevel = logLevelFromEnvironment
+  ? logLevelFromEnvironment
+  : isProduction
+  ? 'info'
+  : 'debug';
 
 export const getLogger = mozlog({
   app: 'FirefoxProfiler',
-  level: isProduction ? 'INFO' : 'verbose',
+  level: logLevel,
   fmt: isProduction ? 'heka' : 'pretty',
   debug: !isProduction, // This asserts a correct usage of the library
 });

--- a/src/log.js
+++ b/src/log.js
@@ -17,3 +17,6 @@ export const getLogger = mozlog({
   fmt: isProduction ? 'heka' : 'pretty',
   debug: !isProduction, // This asserts a correct usage of the library
 });
+
+type ExtractReturnType = <T>((...rest: any) => T) => T;
+export type Logger = $Call<ExtractReturnType, typeof getLogger>;


### PR DESCRIPTION
Another super simple PR, that brings the following improvements, in 3 commits:
1. defines a Logger type. This will help keep a logger instance in variables and have it typed properly.
2. adjust the default logger level to "debug" instead of "verbose", but make it configurable to set it to verbose if necessary (including in production). This makes it possible to add super verbose logs without them showing up by default. The logLevel is also exposed so that we can change some behavior if necessary, and we use that in the following commit already.
3. the request logger isn't running in tests by default, but this change enables it when the log level is manually set to "verbose".

About 2: maybe it would be better to expose a function so that we could check for example `if (wouldBeLogged('info'))`. I didn't need that for now but tell me what you think. This could be useful for performance, so that if we want to compute something costly to log at "debug" we could avoid it. Tell me whart you think.