### PR TITLE
Implement a publishing route like the python server did

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ yarn-error.log
 node_modules/
 .DS_Store
 dist/
-local-config.json
+.env

--- a/__mocks__/@google-cloud/storage.js
+++ b/__mocks__/@google-cloud/storage.js
@@ -39,6 +39,10 @@ class MockBucket {
   file(path: string) {
     return this.files[path] || (this.files[path] = new MockFile(path));
   }
+
+  exists() {
+    return [true];
+  }
 }
 
 type Metadata = {

--- a/__mocks__/@google-cloud/storage.js
+++ b/__mocks__/@google-cloud/storage.js
@@ -1,0 +1,87 @@
+// @flow
+// This was mostly stolen from https://gist.github.com/nfarina/90ba99a5187113900c86289e67586aaa.
+// And then rewritten to remove the dependency to stream-buffers and add the
+// `exists` method.
+// Thanks!
+
+//
+// Quick & Dirty Google Cloud Storage emulator for tests.
+//
+// `new MockStorage().bucket('my-bucket').file('my_file').createWriteStream()`
+//
+
+import { Readable } from 'stream';
+import { Concatenator } from '../../src/utils/streams';
+
+class MockStorage {
+  static buckets: { [name: string]: MockBucket } = {};
+  static cleanUp() {
+    this.buckets = {};
+  }
+
+  bucket(name: string) {
+    return (
+      MockStorage.buckets[name] ||
+      (MockStorage.buckets[name] = new MockBucket(name))
+    );
+  }
+}
+
+class MockBucket {
+  name: string;
+  files: { [path: string]: MockFile };
+
+  constructor(name: string) {
+    this.name = name;
+    this.files = {};
+  }
+
+  file(path: string) {
+    return this.files[path] || (this.files[path] = new MockFile(path));
+  }
+}
+
+type Metadata = {
+  +metadata: { ... },
+  ...
+};
+
+class MockFile {
+  name: string;
+  contents: Buffer;
+  metadata: Metadata;
+
+  constructor(name: string) {
+    this.name = name;
+    this.contents = Buffer.alloc(0);
+    this.metadata = {};
+  }
+
+  get() {
+    return [this, this.metadata];
+  }
+
+  setMetadata(metadata: Metadata) {
+    const customMetadata = { ...this.metadata.metadata, ...metadata.metadata };
+    this.metadata = { ...this.metadata, ...metadata, metadata: customMetadata };
+  }
+
+  createReadStream() {
+    const readable = new Readable({ autoDestroy: true });
+    readable.push(this.contents);
+    readable.push(null);
+    return readable;
+  }
+
+  createWriteStream({ metadata }: Object) {
+    this.setMetadata(metadata);
+    const writable = new Concatenator();
+    writable.on('finish', () => {
+      this.contents = writable.transferContents();
+      writable.destroy();
+    });
+    return writable;
+  }
+}
+
+export { MockStorage as Storage, MockBucket as Bucket, MockFile as File };

--- a/docs-developer/google-storage.md
+++ b/docs-developer/google-storage.md
@@ -1,0 +1,126 @@
+# Google Cloud Storage
+
+This file documents how to configure Google Cloud Storage to use on your
+machine.
+
+To work on this project this isn't mandatory: it's possible to use a mocked
+version of the service.
+
+## Configure Google platform for this project.
+
+If you're a Mozilla employee, you can jump directly to the last paragraph in
+this section.
+
+Otherwise you can start following the steps starting at the first paragraph.
+
+### Create a project
+
+Here we'll create a new project in the Google Cloud Platform ecosystem.
+
+1. Connect to [your cloud console](https://console.cloud.google.com/). Take care
+   that you use the Google account you want from the top right menu.
+2. Click `Select a project` at the top, then choose `New Project` at the top
+   right of the modal.
+
+### Configure Google Storage
+
+In this part we'll create a socalled *bucket* to hold our uploaded data.
+
+1. Select the option `Storage > Storage` in the menu at the left. Note: you can
+   pin this option so that you can always find it at the top of this menu. [You
+   can also bookmark this direct link](https://console.cloud.google.com/storage/browser).
+2. To enable this API you'll need to sign up for a free trial, including
+   configuring your billing and payment options. You'll have the option to
+   access it from this page if it's not done yet.
+   **As said above configuring GCS isn't necessary to contribute to this project.**
+
+### Create the `profile publisher` role
+
+Then we'll create a role to make it easier to configure permissions, and update
+them in the future.
+
+1. Access the Role configuration through [IAM > Roles](https://console.cloud.google.com/iam-admin/roles).
+2. Click on `Create role` at the top of the page.
+3. You can name this role `profile publisher` and change the description if you
+   wish. You can also change the ID name to `profile.publisher`, and the *Role launch
+   stage* to `General Availability`.
+4. Then you can add some permissions. To search for the permissions, you can
+   enter terms in the _Filter table_ input, **not** the _Filter permissions by role_
+   input.
+   You can search for `storage.objects`, and select the following permissions:
+   * `storage.objects.create`: allows to create objects
+   * `storage.objects.delete`: allows to overwrite existing objects
+   * `storage.buckets.get`: allows to check if the bucket exists
+5. Finally click on `Create` at the bottom.
+
+### Create a Service Account
+
+In this part we'll create a service account with the *profile publisher*
+role that can access the API. We prefer to have a different account for each
+developer rather than share the account.
+
+You can follow these steps:
+
+1. Connect to [IAM > Service accounts part in your console](https://console.cloud.google.com/iam-admin/serviceaccounts).
+2. Make sure the right project is selected at the top. If you have several
+   Google accounts, you might need to change your Google account at the top
+   right as well.
+3. Click on the button `Create service account` near the top of the page.
+4. Chose a descriptive name, like `profiler-server-<name>-dev`. You can add a
+   description as well.
+5. Don't create any new role yet, we'll assign some more later.
+6. Click on `Create key`, and download it as JSON. Store it on your local disk.
+7. Keep the full email for this account in your clipboard, as we'll need it
+   later.
+
+### Create a bucket and assign the right permissions to the service account
+
+In this paragraph we'll create a new bucket and assign permissions to the
+previously created service account.
+
+1. Now you can create a bucket from the [Storage
+   browser](https://console.cloud.google.com/storage/browser). According to the
+   [Google princing page](https://cloud.google.com/storage/pricing), if you
+   choose the regions `us-west1`, `us-central1`, or `us-east1` it should be free
+   if you stay below some threshold. Otherwise keep the other options at their
+   default values.
+2. Now from the same browser you can select the newly created bucket by clicking
+   its checkbox. At the right panel you can click *Add member*.
+3. Copy the full service account email in the field, then press Enter. (*Don't
+   use the autocomplete box as sometimes it doesn't work properly.*)
+4. In the _Role_ part, look for `profile publisher` and add it.
+5. Finally *save* the form.
+
+### You're a Mozilla employee
+
+If you're a Mozilla employee, you can instead request access to the project
+`moz-fx-dev-jwajsberg-profiler`, part of the Mozilla GCP instance.
+
+Then you can create a service account and assign the right permissions for this
+new account to the existing bucket in the project as outlined above. Note that
+this bucket will be emptied from time to time.
+
+## Configure your local development instance to use GCS
+
+Create a file in your project directory, called `local-config.json`. Here is the
+content it should have:
+```json
+{
+  "gcsBucket": "<bucket name>",
+  "googleAuthenticationFile": "<path to your key file>.json"
+}
+```
+
+If you're using the Mozilla project, the bucket name you can use is
+`profile-store-julien-dev`. Otherwise please use the one you created in the
+first step above.
+
+## Configure your local development instance to use a mock version of GCS
+
+Create a file in your project directory, called `local-config.json`. Here is the
+content it should have:
+```json
+{
+    "googleAuthenticationFile": "MOCKED"
+}
+```

--- a/docs-developer/google-storage.md
+++ b/docs-developer/google-storage.md
@@ -102,13 +102,11 @@ this bucket will be emptied from time to time.
 
 ## Configure your local development instance to use GCS
 
-Create a file in your project directory, called `local-config.json`. Here is the
+Create a file in your project directory, called `.env`. Here is the
 content it should have:
-```json
-{
-  "gcsBucket": "<bucket name>",
-  "googleAuthenticationFile": "<path to your key file>.json"
-}
+```
+GCS_BUCKET="<bucket name>"
+GCS_AUTHENTICATION_PATH="<path to your key file>.json"
 ```
 
 If you're using the Mozilla project, the bucket name you can use is
@@ -117,10 +115,8 @@ first step above.
 
 ## Configure your local development instance to use a mock version of GCS
 
-Create a file in your project directory, called `local-config.json`. Here is the
+Create a file in your project directory, called `.env`. Here is the
 content it should have:
-```json
-{
-    "googleAuthenticationFile": "MOCKED"
-}
+```
+GCS_AUTHENTICATION_PATH="MOCKED"
 ```

--- a/docs-developer/google-storage.md
+++ b/docs-developer/google-storage.md
@@ -8,8 +8,8 @@ version of the service.
 
 ## Configure Google platform for this project.
 
-If you're a Mozilla employee, you can jump directly to the last paragraph in
-this section.
+If you're a Mozilla employee, you can [jump directly to the last paragraph in
+this section](#youre-a-mozilla-employee).
 
 Otherwise you can start following the steps starting at the first paragraph.
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@google-cloud/storage": "^4.0.0",
     "@koa/router": "^8.0.1",
     "convict": "^5.1.0",
+    "dotenv": "^8.2.0",
     "fast-crc32c": "^2.0.0",
     "koa": "^2.8.1",
     "koa-logger": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     }
   },
   "dependencies": {
+    "@google-cloud/storage": "^4.0.0",
     "@koa/router": "^8.0.1",
     "convict": "^5.1.0",
     "koa": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@google-cloud/storage": "^4.0.0",
     "@koa/router": "^8.0.1",
     "convict": "^5.1.0",
+    "fast-crc32c": "^2.0.0",
     "koa": "^2.8.1",
     "koa-logger": "^3.2.1",
     "mozlog": "^2.2.0"

--- a/src/config.js
+++ b/src/config.js
@@ -40,25 +40,6 @@ function loadConfig() {
     },
   });
 
-  if (conf.get('env') !== 'test') {
-    // We don't want to run a local configuration file for tests so that we
-    // ensure that they'll always run the same in all environments.
-    try {
-      // Load local configuration if present.
-      conf.loadFile('./local-config.json');
-      log.debug(
-        'local_configuration',
-        `Local configuration file 'local-config.json' was found and loaded.`
-      );
-    } catch (e) {
-      // But it's OK if it's absent.
-      log.debug(
-        'local_configuration',
-        `Local configuration file 'local-config.json' was not found, but it's OK.`
-      );
-    }
-  }
-
   conf.validate();
 
   return conf.getProperties();

--- a/src/config.js
+++ b/src/config.js
@@ -23,6 +23,21 @@ function loadConfig() {
       // see https://github.com/mozilla-services/Dockerflow#containerized-app-requirements
       env: 'PORT',
     },
+    gcsBucket: {
+      doc: `The bucket in Google Cloud Storage we'll use to store files.`,
+      format: String,
+      default: 'profile-store',
+      env: 'GCS_BUCKET',
+    },
+    googleAuthenticationFilePath: {
+      // This holds the path to an authentication file, downloaded from the
+      // Google Cloud Console.
+      // Use the value "MOCKED" to use our mocked version of the service.
+      doc: 'Path to the authentication file for Google Services',
+      format: String,
+      default: '',
+      env: 'GCS_AUTHENTICATION_PATH',
+    },
   });
 
   if (conf.get('env') !== 'test') {
@@ -45,12 +60,15 @@ function loadConfig() {
   }
 
   conf.validate();
+
   return conf.getProperties();
 }
 
 type Config = {|
   +env: string,
   +httpPort: number,
+  +gcsBucket: string,
+  +googleAuthenticationFilePath: string,
 |};
 
 export const config: Config = loadConfig();

--- a/src/dotenv.js
+++ b/src/dotenv.js
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+import dotenv from 'dotenv';
+
+if (process.env.NODE_ENV !== 'test') {
+  // We don't want to run a local configuration file for tests so that we
+  // ensure that they'll always run the same in all environments.
+  dotenv.config();
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
+// Import dotenv configuration as early as possible, so that other modules that
+// depend on environment variables can access the values specified in .env.
+import './dotenv';
 import { createApp } from './app';
 import { config } from './config';
 import { getLogger } from './log';

--- a/src/logic/gcs.js
+++ b/src/logic/gcs.js
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+// This file contains the logic we use to access Google Cloud Storage, aka GCS.
+// Especially it implements two classes for the same interface: one class access
+// the real GCS backend while the other class provides a fake service, suitable
+// when developing without network or without a GCS account.
+
+import { Storage, type Bucket } from '@google-cloud/storage';
+import { Writable } from 'stream';
+
+import { getLogger } from '../log';
+
+/**
+ * This is the interface we implement for outside consumption. This is very
+ * simple because we don't need a lot of functionality.
+ */
+interface GcsStorage {
+  ping(): Promise<void>;
+  getWriteStreamForFile(filePath: string): Writable;
+}
+
+/**
+ * This class reaches the real GCS service.
+ */
+class RealGcsStorage implements GcsStorage {
+  bucket: Bucket;
+
+  constructor(bucket: any) {
+    this.bucket = bucket;
+  }
+
+  async ping(): Promise<void> {
+    const [result] = await this.bucket.exists();
+    if (!result) {
+      throw new Error(`The bucket ${this.bucket.name} doesn't exist.`);
+    }
+  }
+
+  getWriteStreamForFile(filePath: string): Writable {
+    const file = this.bucket.file(filePath);
+    const googleStorageStream = file.createWriteStream({
+      public: true, // Our content is already gzipped
+      resumable: false,
+      gzip: false,
+      metadata: {
+        contentType: 'text/plain',
+        cacheControl: 'max-age: 365000000, immutable',
+        contentEncoding: 'gzip',
+      },
+    });
+    return googleStorageStream;
+  }
+}
+
+/**
+ * This class implements a fake service.
+ */
+class MockGcsStorage implements GcsStorage {
+  ping() {
+    return Promise.resolve();
+  }
+
+  getWriteStreamForFile() {
+    // We create a Writable stream that just consumes everything.
+    const sinkWriteStream = new Writable({
+      write(chunk, encoding, callback) {
+        callback();
+      },
+    });
+    return sinkWriteStream;
+  }
+}
+
+type GcsConfig = {
+  // If the string 'MOCKED' is passed then the mocked service is returned.
+  +googleAuthenticationFilePath: string,
+  +gcsBucket: string,
+};
+
+/**
+ * This is the way to access one of the two implementations, depending on the
+ * parameter.
+ */
+export function create(config: GcsConfig): GcsStorage {
+  const log = getLogger('gcs.create');
+  const googleAuthenticationFilePath = config.googleAuthenticationFilePath;
+  if (googleAuthenticationFilePath === 'MOCKED') {
+    log.debug('gcs_mocked', 'Returning the mocked Storage backend.');
+    return new MockGcsStorage();
+  }
+
+  const gcsBucket = config.gcsBucket;
+  if (!gcsBucket) {
+    throw new Error('The bucket name should not be empty');
+  }
+
+  log.debug('gcs_real', 'Returning the real Storage backend.');
+  const storage = new Storage({
+    keyFilename: googleAuthenticationFilePath,
+  });
+  const bucket = storage.bucket(gcsBucket);
+
+  return new RealGcsStorage(bucket);
+}

--- a/src/logic/gcs.js
+++ b/src/logic/gcs.js
@@ -41,10 +41,14 @@ class RealGcsStorage implements GcsStorage {
 
   getWriteStreamForFile(filePath: string): Writable {
     const file = this.bucket.file(filePath);
+
+    // This uses fast-crc32c under the hood, to compute the crc32c checksum of
+    // the sent data and compare with the checksum google sends back after
+    // upload.
     const googleStorageStream = file.createWriteStream({
-      public: true, // Our content is already gzipped
+      public: true,
       resumable: false,
-      gzip: false,
+      gzip: false, // Our content is already gzipped
       metadata: {
         contentType: 'text/plain',
         cacheControl: 'max-age: 365000000, immutable',

--- a/src/routes/dockerflow.js
+++ b/src/routes/dockerflow.js
@@ -9,7 +9,13 @@
 import Router from '@koa/router';
 import fs from 'fs';
 
+import { getLogger } from '../log';
+import { config } from '../config';
+import { create as gcsStorageCreate } from '../logic/gcs';
+
 export function dockerFlowRoutes() {
+  const log = getLogger('dockerFlowRoutes');
+
   const router = new Router();
 
   // "Respond to /__version__ with the contents of /app/version.json."
@@ -40,8 +46,11 @@ export function dockerFlowRoutes() {
   // check backing services like a database for connectivity and may respond
   // with the status of backing services and application components as a JSON
   // payload."
-  router.get('/__heartbeat__', ctx => {
-    // TODO Later we'll need to ping back-end services like google storage.
+  router.get('/__heartbeat__', async ctx => {
+    // In this heartbeat endpoint, we need to ping 3rd party servers.
+    const storage = gcsStorageCreate(config);
+    await storage.ping();
+    log.debug('heartbeat_gcs', 'GCS ping was successful.');
     ctx.body = 'OK';
   });
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -5,9 +5,11 @@
 
 import Router from '@koa/router';
 import { dockerFlowRoutes } from './dockerflow';
+import { publishRoutes } from './publish';
 
 export function routes() {
   const router = new Router();
   router.use(dockerFlowRoutes().routes());
+  router.use(publishRoutes().routes());
   return router;
 }

--- a/src/routes/publish.js
+++ b/src/routes/publish.js
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+// In this router is implemented the publishing operation. After doing various
+// checks the data is uploaded to Google Cloud Storage.
+
+import Router from '@koa/router';
+import Stream from 'stream';
+import util from 'util';
+
+import { getLogger } from '../log';
+import { config } from '../config';
+import { create as gcsStorageCreate } from '../logic/gcs';
+import {
+  HasherPassThrough,
+  LengthCheckerPassThrough,
+  Concatenator,
+} from '../utils/streams';
+
+const MAX_BODY_LENGTH = 32 * 1024 * 1024; // 32MB
+
+export function publishRoutes() {
+  const log = getLogger('routes.publish');
+
+  const router = new Router();
+
+  router.post('/compressed-store', async ctx => {
+    log.verbose('/compressed-store');
+    const expectedLength = ctx.request.length;
+
+    if (expectedLength !== undefined && expectedLength > MAX_BODY_LENGTH) {
+      log.verbose(
+        'length-header-check',
+        'The length specifided in the header Content-Length is too big.'
+      );
+      ctx.status = 413;
+      return;
+    }
+
+    const hasherTransform = new HasherPassThrough();
+    const lengthChecker = new LengthCheckerPassThrough(MAX_BODY_LENGTH);
+    const concatener = new Concatenator();
+
+    const pipeline = util.promisify(Stream.pipeline);
+    await pipeline(ctx.req, lengthChecker, hasherTransform, concatener);
+
+    const storage = gcsStorageCreate(config);
+    const hash = hasherTransform.sha1();
+
+    const googleStorageStream = storage.getWriteStreamForFile(hash);
+
+    // We can't use Stream.finished here because of a problem with Google's
+    // library. For more information, you can see
+    // https://github.com/googleapis/nodejs-storage/issues/937
+    await new Promise((resolve, reject) => {
+      const fullContent = concatener.transferContents();
+      googleStorageStream.once('error', reject);
+      googleStorageStream.once('finish', resolve);
+      googleStorageStream.end(fullContent);
+    });
+    googleStorageStream.destroy();
+
+    // This should be fine in this case.
+    // eslint-disable-next-line require-atomic-updates
+    ctx.body = hash;
+  });
+
+  return router;
+}

--- a/src/routes/publish.js
+++ b/src/routes/publish.js
@@ -33,7 +33,7 @@ export function publishRoutes() {
     if (expectedLength !== undefined && expectedLength > MAX_BODY_LENGTH) {
       log.verbose(
         'length-header-check',
-        'The length specifided in the header Content-Length is too big.'
+        'The length specified in the header Content-Length is too big.'
       );
       ctx.status = 413;
       return;

--- a/src/types/libdef/npm-custom/@google-cloud/storage_vx.x.x.js
+++ b/src/types/libdef/npm-custom/@google-cloud/storage_vx.x.x.js
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+// In this file we type only the API we use in the project. If we use more API
+// later this will need to be completed.
+
+declare module '@google-cloud/storage' {
+  // Source: https://googleapis.dev/nodejs/storage/latest/global.html#CreateWriteStreamOptions
+  declare type CreateWriteStreamOptions = {|
+    configPath: string,
+    contentType: string,
+    gzip: boolean | 'auto',
+    metadata: { ... },
+    offset: number,
+    predefinedAcl: string,
+    private: boolean,
+    public: boolean,
+    resumable: boolean,
+    uri: string,
+    userProject: string,
+    validation: 'md5' | 'crc32c' | false,
+  |};
+  // Source: https://googleapis.dev/nodejs/storage/latest/File.html
+  declare export class File {
+    constructor(
+      bucket: Bucket,
+      name: string,
+      options?: $Shape<{|
+        encryptionKey: string,
+        generation: number,
+        kmsKeyName: string,
+        userProject: string,
+      |}>
+    ): File;
+
+    // Source: https://googleapis.dev/nodejs/storage/latest/File.html#createWriteStream
+    createWriteStream(
+      options?: $Shape<CreateWriteStreamOptions>
+    ): stream$Writable;
+  }
+
+  // Source: https://googleapis.dev/nodejs/storage/latest/Bucket.html
+  declare export class Bucket {
+    name: string;
+
+    constructor(
+      storage: Storage,
+      name: string,
+      options?: $Shape<{| userProject: string |}>
+    ): Bucket;
+
+    // Source: https://googleapis.dev/nodejs/storage/latest/Bucket.html#exists
+    exists(
+      options?: $Shape<{| userProject: string |}>,
+      callback?: (err: ?Error, exists: boolean) => mixed
+    ): Promise<[boolean]>;
+
+    // Source: https://googleapis.dev/nodejs/storage/latest/Bucket.html#file
+    file(
+      name: string,
+      options?: $Shape<{|
+        generation: string | number,
+        encryptionKey: string,
+        kmsKeyName: string,
+      |}>
+    ): File;
+  }
+
+  // Source: https://googleapis.dev/nodejs/storage/latest/global.html#StorageOptions
+  declare type StorageOptions = {|
+    projectId: string,
+    keyFilename: string,
+    email: string,
+    credentials: $Shape<{|
+      client_email: string,
+      private_key: string,
+    |}>,
+    autoRetry: boolean,
+    maxRetries: number,
+    promise: typeof Promise,
+  |};
+
+  // Source: https://googleapis.dev/nodejs/storage/latest/Storage.html
+  declare export class Storage {
+    constructor(options: ?$Shape<StorageOptions>): Storage;
+
+    // Source: https://googleapis.dev/nodejs/storage/latest/Storage.html#bucket
+    bucket(
+      name: string,
+      options?: $Shape<{| kmsKeyName: string, userProject: string |}>
+    ): Bucket;
+  }
+}

--- a/src/types/libdef/npm-custom/dotenv_v8.x.x.js
+++ b/src/types/libdef/npm-custom/dotenv_v8.x.x.js
@@ -1,0 +1,23 @@
+// @flow
+
+declare module 'dotenv' {
+  declare type ParseResult = {| [key: string]: string |};
+  declare type ConfigResult = {| parsed: ParseResult |} | {| error: Error |};
+  declare function config(
+    options?: $Shape<{| path: string, encoding: string, debug: boolean |}>
+  ): ConfigResult;
+
+  declare function parse(
+    buffer: Buffer | string,
+    options?: $Shape<{| debug: boolean |}>
+  ): ParseResult;
+
+  declare module.exports: {|
+    config: typeof config,
+    parse: typeof parse,
+  |};
+}
+
+// eslint-disable-next-line no-empty
+declare module 'dotenv/config' {
+}

--- a/src/utils/streams.js
+++ b/src/utils/streams.js
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+// This file holds various utilities about streams.
+
+import { Transform, Writable } from 'stream';
+import crypto from 'crypto';
+
+import { getLogger, type Logger } from '../log';
+
+/**
+ * This transform computes a sha1 of the daa passing through it, but otherwise
+ * doesn't alter the data.
+ */
+export class HasherPassThrough extends Transform {
+  log: Logger = getLogger('HasherPassThrough');
+  sha1Hasher: crypto$Hash = crypto.createHash('sha1');
+  sha1Result: string | null = null;
+
+  _transform(chunk: *, encoding: *, callback: *) {
+    this.sha1Hasher.update(chunk);
+    this.push(chunk);
+    callback();
+  }
+
+  sha1() {
+    this.log.verbose('sha1()');
+    if (this.sha1Result === null) {
+      this.sha1Result = this.sha1Hasher.digest('hex');
+    }
+    return this.sha1Result;
+  }
+}
+
+/**
+ * This transform's sole goal is to check that the size of the streamed data
+ * stays within some limit.
+ */
+export class LengthCheckerPassThrough extends Transform {
+  log: Logger = getLogger('LengthCheckerPassThrough');
+  maxLength: number;
+  length: number = 0;
+
+  constructor(maxLength: number) {
+    super();
+    this.maxLength = maxLength;
+  }
+
+  _transform(chunk: *, encoding: *, callback: *) {
+    this.length += chunk.length;
+    this.log.verbose(
+      'length-checker-length',
+      `Added chunk's length is ${chunk.length}, current length is ${this.length}`
+    );
+
+    if (this.length > this.maxLength) {
+      // Using debug instead of verbose will make it possible to assert it in
+      // tests that we actually checked the length through this class.
+      this.log.debug('length-checker-length-error');
+      callback(
+        new Error(
+          `The length is bigger than the configured maximum ${this.maxLength}.`
+        )
+      );
+      return;
+    }
+
+    this.push(chunk);
+    callback();
+  }
+}
+
+/**
+ * This writable stream keeps all received chunks until the stream is closed.
+ * Then the chunks are concatenated into a unique Buffer that can be retrieved.
+ */
+export class Concatenator extends Writable {
+  log: Logger = getLogger('Concatenator');
+  chunks: Buffer[] = [];
+  contents: Buffer | null = null;
+
+  constructor() {
+    super({ decodeStrings: false });
+  }
+
+  _write(chunk: *, encoding: *, callback: *) {
+    if (!(chunk instanceof Buffer)) {
+      callback(new Error(`This stream doesn't support strings.`));
+      return;
+    }
+
+    this.chunks.push(chunk);
+    callback();
+  }
+
+  _destroy(err: *, callback: *) {
+    this.chunks.length = 0;
+    this.contents = null;
+    callback();
+  }
+
+  _final(callback: *) {
+    this.contents = Buffer.concat(this.chunks);
+    this.chunks.length = 0;
+    callback();
+  }
+
+  transferContents(): Buffer {
+    const contents = this.contents;
+    if (contents === null) {
+      throw new Error(`Can't transfer before the stream has been closed.`);
+    }
+    this.contents = null;
+    return contents;
+  }
+}

--- a/src/utils/streams.js
+++ b/src/utils/streams.js
@@ -11,12 +11,15 @@ import crypto from 'crypto';
 import { getLogger, type Logger } from '../log';
 
 /**
- * This transform computes a sha1 of the daa passing through it, but otherwise
+ * This transform computes a sha1 of the data passing through it, but otherwise
  * doesn't alter the data.
  */
 export class HasherPassThrough extends Transform {
   log: Logger = getLogger('HasherPassThrough');
-  sha1Hasher: crypto$Hash = crypto.createHash('sha1');
+  sha1Hasher = crypto.createHash('sha1');
+
+  // This variable holds the result of the sha operation, because `hash.digest`
+  // can be called only once.
   sha1Result: string | null = null;
 
   _transform(chunk: *, encoding: *, callback: *) {
@@ -25,7 +28,9 @@ export class HasherPassThrough extends Transform {
     callback();
   }
 
-  sha1() {
+  // This method returns the computed sha1 from the data that passed through the
+  // transform.
+  sha1(): string {
     this.log.verbose('sha1()');
     if (this.sha1Result === null) {
       this.sha1Result = this.sha1Hasher.digest('hex');

--- a/src/utils/streams.js
+++ b/src/utils/streams.js
@@ -22,7 +22,11 @@ export class HasherPassThrough extends Transform {
   // can be called only once.
   sha1Result: string | null = null;
 
-  _transform(chunk: *, encoding: *, callback: *) {
+  _transform(
+    chunk: string | Buffer,
+    encoding: mixed,
+    callback: (error?: Error) => mixed
+  ) {
     this.sha1Hasher.update(chunk);
     this.push(chunk);
     callback();
@@ -53,7 +57,11 @@ export class LengthCheckerPassThrough extends Transform {
     this.maxLength = maxLength;
   }
 
-  _transform(chunk: *, encoding: *, callback: *) {
+  _transform(
+    chunk: string | Buffer,
+    encoding: mixed,
+    callback: (error?: Error) => mixed
+  ) {
     this.length += chunk.length;
     this.log.verbose(
       'length-checker-length',
@@ -90,7 +98,11 @@ export class Concatenator extends Writable {
     super({ decodeStrings: false });
   }
 
-  _write(chunk: *, encoding: *, callback: *) {
+  _write(
+    chunk: string | Buffer,
+    encoding: mixed,
+    callback: (error?: Error) => mixed
+  ) {
     if (!(chunk instanceof Buffer)) {
       callback(new Error(`This stream doesn't support strings.`));
       return;
@@ -100,13 +112,13 @@ export class Concatenator extends Writable {
     callback();
   }
 
-  _destroy(err: *, callback: *) {
+  _destroy(err: ?Error, callback: (error?: Error) => mixed) {
     this.chunks.length = 0;
     this.contents = null;
     callback();
   }
 
-  _final(callback: *) {
+  _final(callback: (error?: Error) => mixed) {
     this.contents = Buffer.concat(this.chunks);
     this.chunks.length = 0;
     callback();

--- a/test/api/publish.test.js
+++ b/test/api/publish.test.js
@@ -15,7 +15,7 @@ beforeEach(() => MockStorage.cleanUp());
 afterEach(() => MockStorage.cleanUp());
 
 describe('publishing endpoints', () => {
-  function setup() {
+  function getPreconfiguredRequest() {
     const agent = supertest(createApp().callback());
     return agent.post('/compressed-store').type('text');
   }
@@ -31,9 +31,9 @@ describe('publishing endpoints', () => {
       .update(content)
       .digest('hex');
 
-    // `setup` returns a request already configured with the right path and
-    // content type.
-    const req = setup();
+    // `getPreconfiguredRequest` returns a request already configured with the
+    // right path and content type.
+    const req = getPreconfiguredRequest();
 
     // This checks that we get a 200 status from the server and that it returns
     // the hash.
@@ -76,7 +76,7 @@ describe('publishing endpoints', () => {
       .update(content)
       .digest('hex');
 
-    const req = setup();
+    const req = getPreconfiguredRequest();
 
     // When using the low-level API "write", Node generates a "chunked encoding"
     // request without a Content-Length. This is exactly what we want to check
@@ -106,13 +106,13 @@ describe('publishing endpoints', () => {
   });
 
   it('returns an error when the length header is too big', async () => {
-    const req = setup();
+    const req = getPreconfiguredRequest();
     await req.set('Content-Length', String(1024 * 1024 * 1024)).expect(413);
   });
 
   it('returns an error when the sent data is bigger than the length', async () => {
     jest.spyOn(process.stdout, 'write').mockImplementation(() => {});
-    const req = setup();
+    const req = getPreconfiguredRequest();
     await req
       .set('Content-Length', String(3))
       .send('aaaa')
@@ -124,7 +124,7 @@ describe('publishing endpoints', () => {
 
   it('returns an error when the pushed buffer is too big', async () => {
     jest.spyOn(process.stdout, 'write').mockImplementation(() => {});
-    const req = setup();
+    const req = getPreconfiguredRequest();
 
     // When using the low-level API "write", Node generates a "chunked encoding"
     // request without a Content-Length. This is exactly what we want to check

--- a/test/api/publish.test.js
+++ b/test/api/publish.test.js
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+import supertest from 'supertest';
+
+import crypto from 'crypto';
+
+import { Storage as MockStorage } from '../../__mocks__/@google-cloud/storage';
+
+import { config } from '../../src/config';
+import { createApp } from '../../src/app';
+
+beforeEach(() => MockStorage.cleanUp());
+afterEach(() => MockStorage.cleanUp());
+
+describe('publishing endpoints', () => {
+  function setup() {
+    const agent = supertest(createApp().callback());
+    return agent.post('/compressed-store').type('text');
+  }
+
+  it('uploads data all the way to google storage when using a content length', async () => {
+    const content = 'aaaa';
+    const req = setup();
+    await req.send(content).expect(200);
+
+    const contentHash = crypto
+      .createHash('sha1')
+      .update(content)
+      .digest('hex');
+
+    expect(MockStorage.buckets).toHaveProperty(config.gcsBucket);
+
+    const bucket = MockStorage.buckets[config.gcsBucket];
+    expect(bucket.files).toHaveProperty(contentHash);
+
+    const file = bucket.files[contentHash];
+    expect(file).toHaveProperty('contents', Buffer.from(content));
+    expect(file).toHaveProperty('name', contentHash);
+    expect(file).toHaveProperty(
+      'metadata',
+      expect.objectContaining({
+        cacheControl: 'max-age: 365000000, immutable',
+        contentEncoding: 'gzip',
+        contentType: 'text/plain',
+      })
+    );
+  });
+
+  it('uploads data all the way to google storage when using chunked encoding', async () => {
+    const content = 'aaaa';
+    const req = setup();
+
+    // When using the low-level API "write", Node generates a "chunked encoding"
+    // request without a Content-Length. This is exactly what we want to check
+    // here.
+    // Unfortunately there's no easy way to assert we're in this node, we'll
+    // have to rely on the heuristic.
+    req.write(content);
+
+    await req.expect(200);
+
+    const contentHash = crypto
+      .createHash('sha1')
+      .update(content)
+      .digest('hex');
+
+    expect(MockStorage.buckets).toHaveProperty(config.gcsBucket);
+    const bucket = MockStorage.buckets[config.gcsBucket];
+    expect(bucket.files).toHaveProperty(contentHash);
+    const file = bucket.files[contentHash];
+    expect(file).toHaveProperty('contents', Buffer.from(content));
+    expect(file).toHaveProperty('name', contentHash);
+    expect(file).toHaveProperty(
+      'metadata',
+      expect.objectContaining({
+        cacheControl: 'max-age: 365000000, immutable',
+        contentEncoding: 'gzip',
+        contentType: 'text/plain',
+      })
+    );
+  });
+
+  it('returns an error when the length is too big', async () => {
+    const req = setup();
+    await req.set('Content-Length', String(1024 * 1024 * 1024)).expect(413);
+  });
+
+  it('returns an error when the sent data is bigger than the length', async () => {
+    jest.spyOn(process.stdout, 'write').mockImplementation(() => {});
+    const req = setup();
+    await req
+      .set('Content-Length', String(3))
+      .send('aaaa')
+      .expect(400);
+    expect(process.stdout.write).toHaveBeenCalledWith(
+      expect.stringContaining('server_error')
+    );
+  });
+
+  it('returns an error when the pushed buffer is too big', async () => {
+    jest.spyOn(process.stdout, 'write').mockImplementation(() => {});
+    const req = setup();
+
+    // When using the low-level API "write", Node generates a "chunked encoding"
+    // request without a Content-Length. This is exactly what we want to check
+    // here.
+    await req.write(Buffer.alloc(33 * 1024 * 1024));
+
+    const error = await req.then(
+      () => {
+        throw new Error(`The request shouldn't succeed.`);
+      },
+      e => e
+    );
+
+    // We don't get a 413 because the connection is reset without a response.
+    expect(error.code).toBe('ECONNRESET');
+    // This check asserts that we get the error using the
+    // LengthCheckerPassThrough transform. This asserts that we stop the stream
+    // early even without a Content-Length header.
+    expect(process.stdout.write).toHaveBeenCalledWith(
+      expect.stringContaining('length-checker-length-error')
+    );
+    expect(process.stdout.write).toHaveBeenCalledWith(
+      expect.stringContaining('server_error')
+    );
+  });
+});

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -10,10 +10,14 @@ describe('config.js', () => {
     expect(config).toEqual({
       env: 'test',
       httpPort: 4243,
+      gcsBucket: 'profile-store',
+      googleAuthenticationFilePath: '',
     });
     expect(loadConfig()).toEqual({
       env: 'test',
       httpPort: 4243,
+      gcsBucket: 'profile-store',
+      googleAuthenticationFilePath: '',
     });
   });
 

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
-import fs from 'fs';
 import { config, loadConfigForTestsOnly as loadConfig } from '../../src/config';
 
 describe('config.js', () => {
@@ -25,16 +24,5 @@ describe('config.js', () => {
     process.env.PORT = '12345';
     expect(loadConfig().httpPort).toEqual(12345);
     delete process.env.PORT;
-  });
-
-  it('configures other values from a local file', () => {
-    process.env.NODE_ENV = 'production';
-    jest.spyOn(fs, 'readFileSync').mockImplementation(() =>
-      JSON.stringify({
-        httpPort: '12345',
-      })
-    );
-    expect(loadConfig().httpPort).toEqual(12345);
-    process.env.NODE_ENV = 'test';
   });
 });

--- a/test/unit/gcs.test.js
+++ b/test/unit/gcs.test.js
@@ -14,7 +14,7 @@ beforeEach(() => MockStorage.cleanUp());
 afterEach(() => MockStorage.cleanUp());
 
 describe('logic/gcs', () => {
-  it('creates a mock service when asked for', async () => {
+  it('creates a mock service when using the value "MOCKED"', async () => {
     jest.spyOn(Bucket.prototype, 'exists');
     jest.spyOn(Bucket.prototype, 'file');
     const storage = gcsStorageCreate({
@@ -30,7 +30,7 @@ describe('logic/gcs', () => {
     expect(Bucket.prototype.file).not.toHaveBeenCalled();
   });
 
-  it('calls the real service when passed no configuration file', async () => {
+  it('will call the real service when no configuration file path is passed to the library', async () => {
     jest.spyOn(Bucket.prototype, 'exists');
     jest.spyOn(Bucket.prototype, 'file');
 
@@ -46,7 +46,7 @@ describe('logic/gcs', () => {
     expect(Bucket.prototype.file).toHaveBeenCalledWith('filepath');
   });
 
-  it('calls the real service when passed a configuration file', async () => {
+  it('will call the real service when a configuration file path is passed to the library', async () => {
     jest.spyOn(Bucket.prototype, 'exists');
     jest.spyOn(Bucket.prototype, 'file');
 

--- a/test/unit/gcs.test.js
+++ b/test/unit/gcs.test.js
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+import { Writable } from 'stream';
+
+import { Storage as MockStorage } from '../../__mocks__/@google-cloud/storage';
+import { Bucket } from '@google-cloud/storage';
+
+import { create as gcsStorageCreate } from '../../src/logic/gcs';
+
+beforeEach(() => MockStorage.cleanUp());
+afterEach(() => MockStorage.cleanUp());
+
+describe('logic/gcs', () => {
+  it('creates a mock service when asked for', async () => {
+    jest.spyOn(Bucket.prototype, 'exists');
+    jest.spyOn(Bucket.prototype, 'file');
+    const storage = gcsStorageCreate({
+      googleAuthenticationFilePath: 'MOCKED',
+      gcsBucket: '',
+    });
+
+    // This call shouldn't throw nor timeout.
+    await storage.ping();
+    expect(Bucket.prototype.exists).not.toHaveBeenCalled();
+
+    expect(storage.getWriteStreamForFile('filepath')).toBeInstanceOf(Writable);
+    expect(Bucket.prototype.file).not.toHaveBeenCalled();
+  });
+
+  it('calls the real service when passed no configuration file', async () => {
+    jest.spyOn(Bucket.prototype, 'exists');
+    jest.spyOn(Bucket.prototype, 'file');
+
+    const storage = gcsStorageCreate({
+      googleAuthenticationFilePath: '',
+      gcsBucket: 'profile-store',
+    });
+
+    await storage.ping();
+    expect(Bucket.prototype.exists).toHaveBeenCalled();
+
+    expect(storage.getWriteStreamForFile('filepath')).toBeInstanceOf(Writable);
+    expect(Bucket.prototype.file).toHaveBeenCalledWith('filepath');
+  });
+
+  it('calls the real service when passed a configuration file', async () => {
+    jest.spyOn(Bucket.prototype, 'exists');
+    jest.spyOn(Bucket.prototype, 'file');
+
+    const storage = gcsStorageCreate({
+      googleAuthenticationFilePath: '/file/path',
+      gcsBucket: 'profile-store',
+    });
+
+    await storage.ping();
+    expect(Bucket.prototype.exists).toHaveBeenCalled();
+
+    expect(storage.getWriteStreamForFile('filepath')).toBeInstanceOf(Writable);
+    expect(Bucket.prototype.file).toHaveBeenCalledWith('filepath');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1405,6 +1405,13 @@ binary@~0.3.0:
     buffers "~0.1.1"
     chainsaw "~0.1.0"
 
+bindings@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 bluebird@~3.4.1:
   version "3.4.7"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
@@ -2590,6 +2597,13 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
+fast-crc32c@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-crc32c/-/fast-crc32c-2.0.0.tgz#1f7365ec5b47ec23bdfe15c99d13288c9285c6cb"
+  integrity sha512-LIREwygxtxzHF11oLJ4xIVKu/ZWNgrj/QaGvaSD8ZggIsgCyCtSYevlrpWVqNau57ZwezV8K1HFBSjQ7FcRbTQ==
+  optionalDependencies:
+    sse4_crc32 "^6.0.1"
+
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
@@ -2635,6 +2649,11 @@ file-entry-cache@^5.0.1:
   integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
     flat-cache "^2.0.1"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -4744,6 +4763,11 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-addon-api@^1.3.0:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.1.tgz#cf813cd69bb8d9100f6bdca6755fc268f54ac492"
+  integrity sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==
+
 node-environment-flags@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/node-environment-flags/-/node-environment-flags-1.0.6.tgz#a30ac13621f6f7d674260a54dede048c3982c088"
@@ -6125,6 +6149,14 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+sse4_crc32@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/sse4_crc32/-/sse4_crc32-6.0.1.tgz#3511c747ce48a224e0554ebb23d5835ba08a9637"
+  integrity sha512-FUTYXpLroqytNKWIfHzlDWoy9E4tmBB/RklNMy6w3VJs+/XEYAHgbiylg4SS43iOk/9bM0BlJ2EDpFAGT66IoQ==
+  dependencies:
+    bindings "^1.3.0"
+    node-addon-api "^1.3.0"
 
 sshpk@^1.7.0:
   version "1.16.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -737,6 +737,67 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@google-cloud/common@^2.1.1":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@google-cloud/common/-/common-2.2.3.tgz#fc29701b09d7bc9d26ea6b6be119c77485210dbf"
+  integrity sha512-lvw54mGKn8VqVIy2NzAk0l5fntBFX4UwQhHk6HaqkyCQ7WBl5oz4XhzKMtMilozF/3ObPcDogqwuyEWyZ6rnQQ==
+  dependencies:
+    "@google-cloud/projectify" "^1.0.0"
+    "@google-cloud/promisify" "^1.0.0"
+    arrify "^2.0.0"
+    duplexify "^3.6.0"
+    ent "^2.2.0"
+    extend "^3.0.2"
+    google-auth-library "^5.5.0"
+    retry-request "^4.0.0"
+    teeny-request "^5.2.1"
+
+"@google-cloud/paginator@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@google-cloud/paginator/-/paginator-2.0.1.tgz#89ca97933eecfdd7eaa07bd79ed01c9869c9531b"
+  integrity sha512-HZ6UTGY/gHGNriD7OCikYWL/Eu0sTEur2qqse2w6OVsz+57se3nTkqH14JIPxtf0vlEJ8IJN5w3BdZ22pjCB8g==
+  dependencies:
+    arrify "^2.0.0"
+    extend "^3.0.2"
+
+"@google-cloud/projectify@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@google-cloud/projectify/-/projectify-1.0.1.tgz#f654c2ea9de923294ec814ff07c42891abf2d143"
+  integrity sha512-xknDOmsMgOYHksKc1GPbwDLsdej8aRNIA17SlSZgQdyrcC0lx0OGo4VZgYfwoEU1YS8oUxF9Y+6EzDOb0eB7Xg==
+
+"@google-cloud/promisify@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@google-cloud/promisify/-/promisify-1.0.2.tgz#e581aa79ff71fb6074acc1cc59e3d81bf84ce07b"
+  integrity sha512-7WfV4R/3YV5T30WRZW0lqmvZy9hE2/p9MvpI34WuKa2Wz62mLu5XplGTFEMK6uTbJCLWUxTcZ4J4IyClKucE5g==
+
+"@google-cloud/storage@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/storage/-/storage-4.0.0.tgz#ad7df44eb7a7ce469c26d86967c444a7484cf595"
+  integrity sha512-ZhMSvIrsyULJNGuhB3vK9VKxIh92W/sOjEezaxykKewB/NxK/d09cC1AfpwHFcnxN+ZZcy1fSLAIwfNAnKU+lA==
+  dependencies:
+    "@google-cloud/common" "^2.1.1"
+    "@google-cloud/paginator" "^2.0.0"
+    "@google-cloud/promisify" "^1.0.0"
+    arrify "^2.0.0"
+    compressible "^2.0.12"
+    concat-stream "^2.0.0"
+    date-and-time "^0.10.0"
+    duplexify "^3.5.0"
+    extend "^3.0.2"
+    gaxios "^2.0.1"
+    gcs-resumable-upload "^2.2.4"
+    hash-stream-validation "^0.2.2"
+    mime "^2.2.0"
+    mime-types "^2.0.8"
+    onetime "^5.1.0"
+    p-limit "^2.2.0"
+    pumpify "^2.0.0"
+    readable-stream "^3.4.0"
+    snakeize "^0.1.0"
+    stream-events "^1.0.1"
+    through2 "^3.0.0"
+    xdg-basedir "^4.0.0"
+
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"
@@ -1002,6 +1063,13 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 accepts@^1.3.5:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -1165,6 +1233,11 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
+arrify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
+  integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
+
 asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
@@ -1279,6 +1352,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base64-js@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
+  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -1308,6 +1386,11 @@ big-integer@^1.6.17:
   version "1.6.45"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.45.tgz#1bf2fa1271bfd20d4c52c3d6c6f08cab8d91c77e"
   integrity sha512-nmb9E7oEtVJ7SmSCH/DeJobXyuRmaofkpoQSimMFu3HKJ5MADtM825SPLhDuWhZ6TElLAQtgJbQmBZuHIRlZoA==
+
+bignumber.js@^7.0.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
+  integrity sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==
 
 binary-extensions@^1.0.0:
   version "1.13.1"
@@ -1396,6 +1479,11 @@ btoa-lite@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
   integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
+
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -1689,10 +1777,27 @@ component-emitter@^1.2.0, component-emitter@^1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
+compressible@^2.0.12:
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.17.tgz#6e8c108a16ad58384a977f3a482ca20bff2f38c1"
+  integrity sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==
+  dependencies:
+    mime-db ">= 1.40.0 < 2"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+concat-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-2.0.0.tgz#414cf5af790a48c60ab9be4527d56d5e41133cb1"
+  integrity sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.0.2"
+    typedarray "^0.0.6"
 
 configstore@^3.0.0:
   version "3.1.2"
@@ -1705,6 +1810,18 @@ configstore@^3.0.0:
     unique-string "^1.0.0"
     write-file-atomic "^2.0.0"
     xdg-basedir "^3.0.0"
+
+configstore@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/configstore/-/configstore-5.0.0.tgz#37de662c7a49b5fe8dbcf8f6f5818d2d81ed852b"
+  integrity sha512-eE/hvMs7qw7DlcB5JPRnthmrITuHMmACUJAp89v6PT6iOqzoLS7HRWhBtuHMlhNHo2AhUSA/3Dh1bKNJHcublQ==
+  dependencies:
+    dot-prop "^5.1.0"
+    graceful-fs "^4.1.2"
+    make-dir "^3.0.0"
+    unique-string "^2.0.0"
+    write-file-atomic "^3.0.0"
+    xdg-basedir "^4.0.0"
 
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
@@ -1834,6 +1951,11 @@ crypto-random-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
   integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
 
+crypto-random-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
+  integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
+
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
@@ -1861,6 +1983,11 @@ data-urls@^1.0.0:
     abab "^2.0.0"
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
+
+date-and-time@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.10.0.tgz#53825b774167b55fbdf0bbd0f17f19357df7bc70"
+  integrity sha512-IbIzxtvK80JZOVsWF6+NOjunTaoFVYxkAQoyzmflJyuRCJAJebehy48mPiCAedcGp4P7/UO3QYRWa0fe6INftg==
 
 dbug@~0.4.2:
   version "0.4.2"
@@ -2020,6 +2147,13 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
+dot-prop@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.1.1.tgz#85783b39f2a54e04ae1981489a0ef2b9719bbd7d"
+  integrity sha512-QCHI6Lkf+9fJMpwfAFsTvbiSh6ujoPmhCLiDvD/n4dGtLvHfhuBwPdN6z2x4YSOwwtTcLoO/LP70xELWGF/JVA==
+  dependencies:
+    is-obj "^2.0.0"
+
 duplexer2@~0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
@@ -2032,6 +2166,26 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
+duplexify@^3.5.0, duplexify@^3.6.0:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
+  integrity sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==
+  dependencies:
+    end-of-stream "^1.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+    stream-shift "^1.0.0"
+
+duplexify@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-4.1.1.tgz#7027dc374f157b122a8ae08c2d3ea4d2d953aa61"
+  integrity sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==
+  dependencies:
+    end-of-stream "^1.4.1"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+    stream-shift "^1.0.0"
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -2039,6 +2193,13 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -2055,12 +2216,17 @@ emoji-regex@^7.0.1:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
-end-of-stream@^1.1.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+ent@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ent/-/ent-2.2.0.tgz#e964219325a21d05f44466a2f686ed6ce5f5dd1d"
+  integrity sha1-6WQhkyWiHQX0RGai9obtbOX13R0=
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
@@ -2305,6 +2471,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
 exec-sh@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.2.tgz#6738de2eb7c8e671d0366aea0b0db8c6f7d7391b"
@@ -2381,7 +2552,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.2:
+extend@^3.0.0, extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -2438,6 +2609,11 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-text-encoding@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.0.tgz#3e5ce8293409cfaa7177a71b9ca84e1b1e6f25ef"
+  integrity sha512-R9bHCvweUxxwkDwhjav5vxpFvdPGlVngtqmx4pIZfSUhM/Q4NiIUHB456BAf+Q1Nwu3HEZYONtu+Rya+af4jiQ==
 
 fb-watchman@^2.0.0:
   version "2.0.0"
@@ -2679,6 +2855,37 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+gaxios@^2.0.0, gaxios@^2.0.1, gaxios@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-2.1.0.tgz#b5d04ec19bf853d4589ccc2e7d61f0f2ab62afee"
+  integrity sha512-Gtpb5sdQmb82sgVkT2GnS2n+Kx4dlFwbeMYcDlD395aEvsLCSQXJJcHt7oJ2LrGxDEAeiOkK79Zv2A8Pzt6CFg==
+  dependencies:
+    abort-controller "^3.0.0"
+    extend "^3.0.2"
+    https-proxy-agent "^3.0.0"
+    is-stream "^2.0.0"
+    node-fetch "^2.3.0"
+
+gcp-metadata@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-3.2.0.tgz#27d59660f11de411d35b1edb8a41e81389cab5f6"
+  integrity sha512-ympv+yQ6k5QuWCuwQqnGEvFGS7MBKdcQdj1i188v3bW9QLFIchTGaBCEZxSQapT0jffdn1vdt8oJhB5VBWQO1Q==
+  dependencies:
+    gaxios "^2.0.1"
+    json-bigint "^0.3.0"
+
+gcs-resumable-upload@^2.2.4:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/gcs-resumable-upload/-/gcs-resumable-upload-2.3.0.tgz#7d7eef01df5f45f66975ebc0c268d17d9a2c3b9c"
+  integrity sha512-PclXJiEngrVx0c4K0LfE1XOxhmOkBEy39Rrhspdn6jAbbwe4OQMZfjo7Z1LHBrh57+bNZeIN4M+BooYppCoHSg==
+  dependencies:
+    abort-controller "^3.0.0"
+    configstore "^5.0.0"
+    gaxios "^2.0.0"
+    google-auth-library "^5.0.0"
+    pumpify "^2.0.0"
+    stream-events "^1.0.4"
+
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
@@ -2762,6 +2969,27 @@ globals@^11.1.0, globals@^11.7.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
+google-auth-library@^5.0.0, google-auth-library@^5.5.0:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-5.5.1.tgz#2bf5ade93cb9d00c860d3fb15798db33b39a53a7"
+  integrity sha512-zCtjQccWS/EHYyFdXRbfeSGM/gW+d7uMAcVnvXRnjBXON5ijo6s0nsObP0ifqileIDSbZjTlLtgo+UoN8IFJcg==
+  dependencies:
+    arrify "^2.0.0"
+    base64-js "^1.3.0"
+    fast-text-encoding "^1.0.0"
+    gaxios "^2.1.0"
+    gcp-metadata "^3.2.0"
+    gtoken "^4.1.0"
+    jws "^3.1.5"
+    lru-cache "^5.0.0"
+
+google-p12-pem@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-2.0.2.tgz#39cae8f6fcbe66a01f00be4ddf2d56b95926fa7b"
+  integrity sha512-UfnEARfJKI6pbmC1hfFFm+UAcZxeIwTiEcHfqKe/drMsXD/ilnVjF7zgOGpHXyhuvX6jNJK3S8A0hOQjwtFxEw==
+  dependencies:
+    node-forge "^0.9.0"
+
 got@^6.7.1:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
@@ -2811,6 +3039,16 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
+
+gtoken@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-4.1.0.tgz#0b315dd1a925e3ad3c82db1eb5b9e89bae875ba8"
+  integrity sha512-wqyn2gf5buzEZN4QNmmiiW2i2JkEdZnL7Z/9p44RtZqgt4077m4khRgAYNuu8cBwHWCc6MsP6eDUn/KkF6jFIw==
+  dependencies:
+    gaxios "^2.0.0"
+    google-p12-pem "^2.0.0"
+    jws "^3.1.5"
+    mime "^2.2.0"
 
 handlebars@^4.1.2:
   version "4.3.3"
@@ -2908,6 +3146,13 @@ has@^1.0.1, has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hash-stream-validation@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/hash-stream-validation/-/hash-stream-validation-0.2.2.tgz#6b34c4fce5e9fce265f1d3380900049d92a10090"
+  integrity sha512-cMlva5CxWZOrlS/cY0C+9qAzesn5srhFA8IT1VPiHc9bWWBLkJfEUIZr7MWoi89oOOGmpg8ymchaOjiArsGu5A==
+  dependencies:
+    through2 "^2.0.0"
+
 homedir-polyfill@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
@@ -2972,6 +3217,14 @@ https-proxy-agent@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz#271ea8e90f836ac9f119daccd39c19ff7dfb0793"
   integrity sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==
+  dependencies:
+    agent-base "^4.3.0"
+    debug "^3.1.0"
+
+https-proxy-agent@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz#b8c286433e87602311b01c8ea34413d856a4af81"
+  integrity sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==
   dependencies:
     agent-base "^4.3.0"
     debug "^3.1.0"
@@ -3300,6 +3553,11 @@ is-obj@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
 
+is-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
+  integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
+
 is-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
@@ -3351,6 +3609,11 @@ is-stream@^1.0.0, is-stream@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
+is-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+
 is-symbol@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
@@ -3358,7 +3621,7 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.0"
 
-is-typedarray@~1.0.0:
+is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
@@ -3877,6 +4140,13 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
+json-bigint@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-0.3.0.tgz#0ccd912c4b8270d05f056fbd13814b53d3825b1e"
+  integrity sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=
+  dependencies:
+    bignumber.js "^7.0.0"
+
 json-buffer@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
@@ -3930,6 +4200,23 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.1.5:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 keygrip@~1.0.3:
   version "1.0.3"
@@ -4162,6 +4449,13 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
+
 macos-release@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
@@ -4181,6 +4475,13 @@ make-dir@^2.0.0, make-dir@^2.1.0:
   dependencies:
     pify "^4.0.1"
     semver "^5.6.0"
+
+make-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.0.tgz#1b5f39f6b9270ed33f9f054c5c0f84304989f801"
+  integrity sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==
+  dependencies:
+    semver "^6.0.0"
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -4275,7 +4576,12 @@ mime-db@1.40.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
   integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
 
-mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.19, mime-types@~2.1.24:
+"mime-db@>= 1.40.0 < 2":
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.42.0.tgz#3e252907b4c7adb906597b4b65636272cf9e7bac"
+  integrity sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==
+
+mime-types@^2.0.8, mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.24"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
   integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
@@ -4287,12 +4593,17 @@ mime@^1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
+mime@^2.2.0:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
+  integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
+
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
-mimic-fn@^2.0.0:
+mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
@@ -4441,10 +4752,15 @@ node-environment-flags@^1.0.5:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
-node-fetch@^2.1.1:
+node-fetch@^2.1.1, node-fetch@^2.2.0, node-fetch@^2.3.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
+node-forge@^0.9.0:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.1.tgz#775368e6846558ab6676858a4d8c6e8d16c677b5"
+  integrity sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -4698,6 +5014,13 @@ onetime@^2.0.0:
   integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
+
+onetime@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
+  integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
+  dependencies:
+    mimic-fn "^2.1.0"
 
 only@~0.0.2:
   version "0.0.2"
@@ -5143,6 +5466,15 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+pumpify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-2.0.1.tgz#abfc7b5a621307c728b551decbbefb51f0e4aa1e"
+  integrity sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==
+  dependencies:
+    duplexify "^4.1.1"
+    inherits "^2.0.3"
+    pump "^3.0.0"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -5230,6 +5562,15 @@ read-pkg@^5.1.1:
     normalize-package-data "^2.5.0"
     parse-json "^5.0.0"
     type-fest "^0.6.0"
+
+"readable-stream@2 || 3", readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
+  integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.3.5, readable-stream@~2.3.6:
   version "2.3.6"
@@ -5469,6 +5810,14 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+retry-request@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-4.1.1.tgz#f676d0db0de7a6f122c048626ce7ce12101d2bd8"
+  integrity sha512-BINDzVtLI2BDukjWmjAIRZ0oglnCAkpP2vQjM3jdLhmT62h0xnQgciPwBRDAvHqpkPT2Wo1XuUyLyn6nbGrZQQ==
+  dependencies:
+    debug "^4.1.1"
+    through2 "^3.0.1"
+
 rimraf@2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
@@ -5519,7 +5868,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2:
+safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
@@ -5662,6 +6011,11 @@ slice-ansi@^2.1.0:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
+
+snakeize@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/snakeize/-/snakeize-0.1.0.tgz#10c088d8b58eb076b3229bb5a04e232ce126422d"
+  integrity sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0=
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -5815,6 +6169,18 @@ stealthy-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
+stream-events@^1.0.1, stream-events@^1.0.4, stream-events@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/stream-events/-/stream-events-1.0.5.tgz#bbc898ec4df33a4902d892333d47da9bf1c406d5"
+  integrity sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==
+  dependencies:
+    stubs "^3.0.0"
+
+stream-shift@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
+  integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
+
 strftime@~0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/strftime/-/strftime-0.10.0.tgz#b3f0fa419295202a5a289f6d6be9f4909a617193"
@@ -5884,6 +6250,13 @@ string.prototype.trimright@^2.0.0:
     define-properties "^1.1.3"
     function-bind "^1.1.1"
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -5931,6 +6304,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+stubs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/stubs/-/stubs-3.0.0.tgz#e8d2ba1fa9c90570303c030b6900f7d5f89abe5b"
+  integrity sha1-6NK6H6nJBXAwPAMLaQD31fiavls=
 
 superagent@^3.8.3:
   version "3.8.3"
@@ -6008,6 +6386,17 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
+teeny-request@^5.2.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-5.3.1.tgz#3a2a9a479e2d884eba814dc9c0c82b7979e69b4d"
+  integrity sha512-hnUeun3xryzv92FbrnprltcdeDfSVaGFBlFPRvKJ2fO/ioQx9N0aSUbbXSfTO+ArRXine1gSWdWFWcgfrggWXw==
+  dependencies:
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^3.0.0"
+    node-fetch "^2.2.0"
+    stream-events "^1.0.5"
+    uuid "^3.3.2"
+
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
@@ -6034,6 +6423,21 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
   integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
+
+through2@^2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
+  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
+  dependencies:
+    readable-stream "~2.3.6"
+    xtend "~4.0.1"
+
+through2@^3.0.0, through2@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-3.0.1.tgz#39276e713c3302edf9e388dd9c812dd3b825bd5a"
+  integrity sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==
+  dependencies:
+    readable-stream "2 || 3"
 
 through@^2.3.6, through@^2.3.8:
   version "2.3.8"
@@ -6164,6 +6568,18 @@ type-is@^1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
+
+typedarray@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+  integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
 typescript-compiler@^1.4.1-2:
   version "1.4.1-2"
   resolved "https://registry.yarnpkg.com/typescript-compiler/-/typescript-compiler-1.4.1-2.tgz#ba4f7db22d91534a1929d90009dce161eb72fd3f"
@@ -6228,6 +6644,13 @@ unique-string@^1.0.0:
   integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
   dependencies:
     crypto-random-string "^1.0.0"
+
+unique-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
+  integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
+  dependencies:
+    crypto-random-string "^2.0.0"
 
 universal-user-agent@^2.0.0:
   version "2.1.0"
@@ -6341,7 +6764,7 @@ utcstring@~0.1.0:
   resolved "https://registry.yarnpkg.com/utcstring/-/utcstring-0.1.0.tgz#430fd510ab7fc95b5d5910c902d79880c208436b"
   integrity sha1-Qw/VEKt/yVtdWRDJAteYgMIIQ2s=
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
@@ -6530,6 +6953,16 @@ write-file-atomic@^2.0.0:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
+write-file-atomic@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.1.tgz#558328352e673b5bb192cf86500d60b230667d4b"
+  integrity sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==
+  dependencies:
+    imurmurhash "^0.1.4"
+    is-typedarray "^1.0.0"
+    signal-exit "^3.0.2"
+    typedarray-to-buffer "^3.1.5"
+
 write@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
@@ -6549,10 +6982,20 @@ xdg-basedir@^3.0.0:
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
   integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
 
+xdg-basedir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
+  integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xtend@~4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"
@@ -6568,6 +7011,11 @@ yallist@^3.0.0, yallist@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+
+yallist@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yargs-parser@13.0.0:
   version "13.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2161,6 +2161,11 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 duplexer2@~0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"


### PR DESCRIPTION
This implements a publishing route.

The first step is to configure Google Cloud Storage as explained in the markdown file included in this PR.
Then we can test this works like this:
```bash
# In a terminal
yarn start

# In another terminal
curl -i --data-binary @SomeFile -H "Content-Type: application/octet-stream" http://localhost:4243/compressed-store
```
You can also try with `-H "Transfer-Encoding: chunked"`, this should work.

Curl will return the hash of the transfered document, and you should be able to find it in the Google Cloud Console.

For the review, it's split in several commits, maybe it's easier to look at them separately.