### PR TITLE
Implement a mechanism to provide a configuration through a local file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ yarn-error.log
 node_modules/
 .DS_Store
 dist/
+local-config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,6 @@
 # "slim" flavor because we don't need the big version.
 FROM node:10-buster-slim AS builder
 
-ENV NODE_ENV="production"
-ENV PORT=8000
-
 # Create the user we'll run the build commands with. Its home is configured to
 # be the directory /app. It helps avoiding warnings when running tests and
 # building the app later.
@@ -61,7 +58,7 @@ ENV CIRCLE_BUILD_URL=${circle_build_url}
 # faster.
 RUN set -x \
 # Install the dependencies, including dev dependencies.
-  && yarn install --frozen-lockfile --production=false \
+  && yarn install --frozen-lockfile \
 # Run tests
 # Note we don't use test-all because we don't want to start the flow server. So
 # we run all test commands separately.
@@ -70,7 +67,7 @@ RUN set -x \
   && yarn test \
 # Actually build the project.
   && yarn build:clean \
-  && yarn build \
+  && NODE_ENV=production yarn build \
 # This script doesn't work outside of CircleCI
   && if [ -n "$CIRCLE_BUILD_URL" ] ; then yarn generate-version-file ; fi \
 # Then keep only prod dependencies, that we'll copy over to the runtime

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,9 @@
 // @flow
 
 import convict from 'convict';
+import { getLogger } from './log';
+
+const log = getLogger('config');
 
 const conf = convict({
   env: {
@@ -21,6 +24,25 @@ const conf = convict({
   },
 });
 
+if (conf.get('env') !== 'test') {
+  // We don't want to run a local configuration file for tests so that we
+  // ensure that they'll always run the same in all environments.
+  try {
+    // Load local configuration if present.
+    conf.loadFile('./local-config.json');
+    log.debug(
+      'local_configuration',
+      `Local configuration file 'local-config.json' was found and loaded.`
+    );
+  } catch (e) {
+    // But it's OK if it's absent.
+    log.debug(
+      'local_configuration',
+      `Local configuration file 'local-config.json' was not found, but it's OK.`
+    );
+  }
+}
+
 conf.validate();
 
 type Config = {|
@@ -29,3 +51,7 @@ type Config = {|
 |};
 
 export const config: Config = conf.getProperties();
+log.info(
+  'configuration_success',
+  'Configuration info has been loaded successfully.'
+);

--- a/src/config.js
+++ b/src/config.js
@@ -8,50 +8,59 @@ import { getLogger } from './log';
 
 const log = getLogger('config');
 
-const conf = convict({
-  env: {
-    doc: 'The application environment.',
-    format: ['production', 'development', 'test'],
-    default: 'development',
-    env: 'NODE_ENV',
-  },
-  httpPort: {
-    format: 'port',
-    default: 4243,
-    // The environment variable's name is required by Dockerflow.
-    // see https://github.com/mozilla-services/Dockerflow#containerized-app-requirements
-    env: 'PORT',
-  },
-});
+function loadConfig() {
+  const conf = convict({
+    env: {
+      doc: 'The application environment.',
+      format: ['production', 'development', 'test'],
+      default: 'development',
+      env: 'NODE_ENV',
+    },
+    httpPort: {
+      format: 'port',
+      default: 4243,
+      // The environment variable's name is required by Dockerflow.
+      // see https://github.com/mozilla-services/Dockerflow#containerized-app-requirements
+      env: 'PORT',
+    },
+  });
 
-if (conf.get('env') !== 'test') {
-  // We don't want to run a local configuration file for tests so that we
-  // ensure that they'll always run the same in all environments.
-  try {
-    // Load local configuration if present.
-    conf.loadFile('./local-config.json');
-    log.debug(
-      'local_configuration',
-      `Local configuration file 'local-config.json' was found and loaded.`
-    );
-  } catch (e) {
-    // But it's OK if it's absent.
-    log.debug(
-      'local_configuration',
-      `Local configuration file 'local-config.json' was not found, but it's OK.`
-    );
+  if (conf.get('env') !== 'test') {
+    // We don't want to run a local configuration file for tests so that we
+    // ensure that they'll always run the same in all environments.
+    try {
+      // Load local configuration if present.
+      conf.loadFile('./local-config.json');
+      log.debug(
+        'local_configuration',
+        `Local configuration file 'local-config.json' was found and loaded.`
+      );
+    } catch (e) {
+      // But it's OK if it's absent.
+      log.debug(
+        'local_configuration',
+        `Local configuration file 'local-config.json' was not found, but it's OK.`
+      );
+    }
   }
-}
 
-conf.validate();
+  conf.validate();
+  return conf.getProperties();
+}
 
 type Config = {|
   +env: string,
   +httpPort: number,
 |};
 
-export const config: Config = conf.getProperties();
+export const config: Config = loadConfig();
 log.info(
   'configuration_success',
   'Configuration info has been loaded successfully.'
 );
+
+// In tests we want to test how the config loads in several environments.
+// Instead of testing the `config` object we test the result of `loadConfig`
+// directly, so that this doesn't affect the main `config` object while other
+// tests run in parallel.
+export { loadConfig as loadConfigForTestsOnly };

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -3,16 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 import fs from 'fs';
+import { config, loadConfigForTestsOnly as loadConfig } from '../../src/config';
 
 describe('config.js', () => {
-  beforeEach(() => {
-    // Reseting the modules forces Jest to fully reload the "config" module.
-    jest.resetModules();
-  });
-
   it('returns default values', () => {
-    const { config } = require('../../src/config');
     expect(config).toEqual({
+      env: 'test',
+      httpPort: 4243,
+    });
+    expect(loadConfig()).toEqual({
       env: 'test',
       httpPort: 4243,
     });
@@ -20,8 +19,7 @@ describe('config.js', () => {
 
   it('configures other values from environment variables', () => {
     process.env.PORT = '12345';
-    const { config } = require('../../src/config');
-    expect(config.httpPort).toEqual(12345);
+    expect(loadConfig().httpPort).toEqual(12345);
     delete process.env.PORT;
   });
 
@@ -32,8 +30,7 @@ describe('config.js', () => {
         httpPort: '12345',
       })
     );
-    const { config } = require('../../src/config');
-    expect(config.httpPort).toEqual(12345);
+    expect(loadConfig().httpPort).toEqual(12345);
     process.env.NODE_ENV = 'test';
   });
 });

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+import fs from 'fs';
+
+describe('config.js', () => {
+  beforeEach(() => {
+    // Reseting the modules forces Jest to fully reload the "config" module.
+    jest.resetModules();
+  });
+
+  it('returns default values', () => {
+    const { config } = require('../../src/config');
+    expect(config).toEqual({
+      env: 'test',
+      httpPort: 4243,
+    });
+  });
+
+  it('configures other values from environment variables', () => {
+    process.env.PORT = '12345';
+    const { config } = require('../../src/config');
+    expect(config.httpPort).toEqual(12345);
+    delete process.env.PORT;
+  });
+
+  it('configures other values from a local file', () => {
+    process.env.NODE_ENV = 'production';
+    jest.spyOn(fs, 'readFileSync').mockImplementation(() =>
+      JSON.stringify({
+        httpPort: '12345',
+      })
+    );
+    const { config } = require('../../src/config');
+    expect(config.httpPort).toEqual(12345);
+    process.env.NODE_ENV = 'test';
+  });
+});


### PR DESCRIPTION
Such a mechanism will be useful once we start working with Google Storage, because we'll have to configure local values different from the production values.

The configuration values I'm talking about here are:
* the bucket name we use for development
* a filename containing the authentication key to access google's API endpoint.

An alternative is convention over configuration: the configuration for Google Storage will have hardcoded values. But I feel like this is less flexible.

**Important**: 
* there are 2 "flavors" for this PR, the last commit shows the difference. Please tell me your preference. I think my preference is when this last commit is present. The difference is how we test config.js.
* it's probably easier to read the last commit (and so the full PR) without whitespace changes.
