### PR TITLE
Fully restore mocks instead of only reseting them

### DIFF
--- a/test/setup.js
+++ b/test/setup.js
@@ -8,7 +8,11 @@ afterEach(() => {
   // to be working correctly. Manually trigger this call here to ensure we
   // don't get intermittents from one test's mocks affecting another test's mocks.
   //
+  // We use `restoreAllMocks` over `resetAllMocks` because this restores the
+  // mocks to their initial value. `resetAllMocks` would keep the mock and make
+  // them return `undefined`.
+  //
   // See https://github.com/facebook/jest/issues/7654
-  jest.resetAllMocks();
+  jest.restoreAllMocks();
   jest.clearAllTimers();
 });


### PR DESCRIPTION
I think this is what fixes the problem I had in #26. In that test I mock `fs.readFileSync`, and because of the issue fixed in this PR, that mock wasn't restored, only reset.

What I don't understand is that in the profiler UI we had the same thing but never had any problem (maybe because we never mock nodejs APIs?).
Also I think I recall I chose `resetAllMocks` over `restoreAllMocks` when I did it some months ago for a reason. That I don't remember now.

Anyway this fixes my issue and I understand why it does, so I think this is the right fix. I'll do it in the profiler UI next week too.