### PR TITLE
Support a primitive form of versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "@google-cloud/storage": "^4.0.0",
     "@koa/router": "^8.0.1",
+    "content-type": "^1.0.4",
     "convict": "^5.1.0",
     "dotenv": "^8.2.0",
     "fast-crc32c": "^2.0.0",

--- a/src/middlewares/index.js
+++ b/src/middlewares/index.js
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+// This file just reexports all middlewares for an easier access.
+
+export * from './versioning';

--- a/src/middlewares/versioning.js
+++ b/src/middlewares/versioning.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+// This middleware ensures that the request specifies the versioning header and
+// its value is the expected value.
+// In the future we'll want to implement an upgrade mechanism.
+import type { Context } from 'koa';
+
+export const ACCEPT_VALUE_PREFIX =
+  'application/vnd.firefox-profiler+json;version=';
+export function versioning(version: string) {
+  return async function(ctx: Context, next: () => Promise<void>) {
+    const acceptValue = ctx.get('accept');
+    if (!acceptValue) {
+      ctx.throw(400, `The header 'Accept' is missing.`);
+      return;
+    }
+
+    if (!acceptValue.startsWith(ACCEPT_VALUE_PREFIX)) {
+      ctx.throw(
+        400,
+        `The header 'Accept' should have the value ${ACCEPT_VALUE_PREFIX}${version}`
+      );
+      return;
+    }
+
+    const requestedVersion = acceptValue.slice(ACCEPT_VALUE_PREFIX.length);
+    if (requestedVersion !== version) {
+      ctx.throw(
+        406,
+        `Only the API version ${version} is supported by this server.`
+      );
+    }
+
+    await next();
+  };
+}

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -6,10 +6,14 @@
 import Router from '@koa/router';
 import { dockerFlowRoutes } from './dockerflow';
 import { publishRoutes } from './publish';
+import { versioning } from '../middlewares';
 
 export function routes() {
   const router = new Router();
   router.use(dockerFlowRoutes().routes());
+
+  // Versioning applies only to API routes, that's why we specify it here.
+  router.use(versioning('1.0'));
   router.use(publishRoutes().routes());
   return router;
 }

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -13,7 +13,7 @@ export function routes() {
   router.use(dockerFlowRoutes().routes());
 
   // Versioning applies only to API routes, that's why we specify it here.
-  router.use(versioning('1.0'));
+  router.use(versioning(1));
   router.use(publishRoutes().routes());
   return router;
 }

--- a/src/types/libdef/npm-custom/content-type_v1.x.x.js
+++ b/src/types/libdef/npm-custom/content-type_v1.x.x.js
@@ -1,0 +1,23 @@
+// @flow
+declare module 'content-type' {
+  declare type contentType$OutputParsedContentType = {|
+    type: string,
+    parameters: {| [string]: string |},
+  |};
+
+  declare type contentType$InputParsedContentType = {|
+    +type: string,
+    +parameters?: { [string]: string | number, ... },
+  |};
+
+  declare function parse(
+    string | http$IncomingMessage<> | http$ServerResponse
+  ): contentType$OutputParsedContentType;
+
+  declare function format(contentType$InputParsedContentType): string;
+
+  declare module.exports: {|
+    +parse: typeof parse,
+    +format: typeof format,
+  |};
+}

--- a/test/api/__snapshots__/publish.test.js.snap
+++ b/test/api/__snapshots__/publish.test.js.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`API versioning returns an error when an \`accept\` header is specified with an unsupported version 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "[1mFirefoxProfiler.app[22m.[1m[31mERROR[39m[22m: server_error {\\"error\\":\\"NotAcceptableError: The header 'Accept' should have the value application/vnd.firefox-profiler+json; version=1\\",\\"stack\\":\\"NotAcceptableError: The header 'Accept' should have the value application/vnd.firefox-profiler+json; version=1\\\\n    at Object.throw (/home/julien/travail/git/profiler-server/node_modules/koa/lib/context.js:97:11)\\\\n    at /home/julien/travail/git/profiler-server/src/middlewares/versioning.js:50:7\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:44:32)\\\\n    at next (/home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:45:18)\\\\n    at /home/julien/travail/git/profiler-server/node_modules/@koa/router/lib/router.js:346:16\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:44:32)\\\\n    at /home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:36:12\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/@koa/router/lib/router.js:351:31)\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/koa/node_modules/koa-compose/index.js:42:32)\\\\n    at /home/julien/travail/git/profiler-server/node_modules/koa/node_modules/koa-compose/index.js:34:12\\\\n    at Application.handleRequest (/home/julien/travail/git/profiler-server/node_modules/koa/lib/application.js:162:12)\\\\n    at Server.handleRequest (/home/julien/travail/git/profiler-server/node_modules/koa/lib/application.js:144:19)\\\\n    at Server.emit (events.js:210:5)\\\\n    at parserOnIncoming (_http_server.js:745:12)\\\\n    at HTTPParser.parserOnHeadersComplete (_http_common.js:115:17)\\"}
+",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`API versioning returns an error when an accept header is specified with several unacceptable values 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "[1mFirefoxProfiler.app[22m.[1m[31mERROR[39m[22m: server_error {\\"error\\":\\"NotAcceptableError: The header 'Accept' should have the value application/vnd.firefox-profiler+json; version=1\\",\\"stack\\":\\"NotAcceptableError: The header 'Accept' should have the value application/vnd.firefox-profiler+json; version=1\\\\n    at Object.throw (/home/julien/travail/git/profiler-server/node_modules/koa/lib/context.js:97:11)\\\\n    at /home/julien/travail/git/profiler-server/src/middlewares/versioning.js:50:7\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:44:32)\\\\n    at next (/home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:45:18)\\\\n    at /home/julien/travail/git/profiler-server/node_modules/@koa/router/lib/router.js:346:16\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:44:32)\\\\n    at /home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:36:12\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/@koa/router/lib/router.js:351:31)\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/koa/node_modules/koa-compose/index.js:42:32)\\\\n    at /home/julien/travail/git/profiler-server/node_modules/koa/node_modules/koa-compose/index.js:34:12\\\\n    at Application.handleRequest (/home/julien/travail/git/profiler-server/node_modules/koa/lib/application.js:162:12)\\\\n    at Server.handleRequest (/home/julien/travail/git/profiler-server/node_modules/koa/lib/application.js:144:19)\\\\n    at Server.emit (events.js:210:5)\\\\n    at parserOnIncoming (_http_server.js:745:12)\\\\n    at HTTPParser.parserOnHeadersComplete (_http_common.js:115:17)\\"}
+",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`API versioning returns an error when an accept header is specified without a version at all 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "[1mFirefoxProfiler.app[22m.[1m[31mERROR[39m[22m: server_error {\\"error\\":\\"NotAcceptableError: The header 'Accept' should have the value application/vnd.firefox-profiler+json; version=1\\",\\"stack\\":\\"NotAcceptableError: The header 'Accept' should have the value application/vnd.firefox-profiler+json; version=1\\\\n    at Object.throw (/home/julien/travail/git/profiler-server/node_modules/koa/lib/context.js:97:11)\\\\n    at /home/julien/travail/git/profiler-server/src/middlewares/versioning.js:50:7\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:44:32)\\\\n    at next (/home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:45:18)\\\\n    at /home/julien/travail/git/profiler-server/node_modules/@koa/router/lib/router.js:346:16\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:44:32)\\\\n    at /home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:36:12\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/@koa/router/lib/router.js:351:31)\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/koa/node_modules/koa-compose/index.js:42:32)\\\\n    at /home/julien/travail/git/profiler-server/node_modules/koa/node_modules/koa-compose/index.js:34:12\\\\n    at Application.handleRequest (/home/julien/travail/git/profiler-server/node_modules/koa/lib/application.js:162:12)\\\\n    at Server.handleRequest (/home/julien/travail/git/profiler-server/node_modules/koa/lib/application.js:144:19)\\\\n    at Server.emit (events.js:210:5)\\\\n    at parserOnIncoming (_http_server.js:745:12)\\\\n    at HTTPParser.parserOnHeadersComplete (_http_common.js:115:17)\\"}
+",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`API versioning returns an error when an invalid \`accept\` header is specified 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "[1mFirefoxProfiler.app[22m.[1m[31mERROR[39m[22m: server_error {\\"error\\":\\"NotAcceptableError: The header 'Accept' should have the value application/vnd.firefox-profiler+json; version=1\\",\\"stack\\":\\"NotAcceptableError: The header 'Accept' should have the value application/vnd.firefox-profiler+json; version=1\\\\n    at Object.throw (/home/julien/travail/git/profiler-server/node_modules/koa/lib/context.js:97:11)\\\\n    at /home/julien/travail/git/profiler-server/src/middlewares/versioning.js:50:7\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:44:32)\\\\n    at next (/home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:45:18)\\\\n    at /home/julien/travail/git/profiler-server/node_modules/@koa/router/lib/router.js:346:16\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:44:32)\\\\n    at /home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:36:12\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/@koa/router/lib/router.js:351:31)\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/koa/node_modules/koa-compose/index.js:42:32)\\\\n    at /home/julien/travail/git/profiler-server/node_modules/koa/node_modules/koa-compose/index.js:34:12\\\\n    at Application.handleRequest (/home/julien/travail/git/profiler-server/node_modules/koa/lib/application.js:162:12)\\\\n    at Server.handleRequest (/home/julien/travail/git/profiler-server/node_modules/koa/lib/application.js:144:19)\\\\n    at Server.emit (events.js:210:5)\\\\n    at parserOnIncoming (_http_server.js:745:12)\\\\n    at HTTPParser.parserOnHeadersComplete (_http_common.js:115:17)\\"}
+",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`API versioning returns an error when no \`accept\` header is specified 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "[1mFirefoxProfiler.app[22m.[1m[31mERROR[39m[22m: server_error {\\"error\\":\\"BadRequestError: The header 'Accept' is missing.\\",\\"stack\\":\\"BadRequestError: The header 'Accept' is missing.\\\\n    at Object.throw (/home/julien/travail/git/profiler-server/node_modules/koa/lib/context.js:97:11)\\\\n    at /home/julien/travail/git/profiler-server/src/middlewares/versioning.js:25:7\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:44:32)\\\\n    at next (/home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:45:18)\\\\n    at /home/julien/travail/git/profiler-server/node_modules/@koa/router/lib/router.js:346:16\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:44:32)\\\\n    at /home/julien/travail/git/profiler-server/node_modules/koa-compose/index.js:36:12\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/@koa/router/lib/router.js:351:31)\\\\n    at dispatch (/home/julien/travail/git/profiler-server/node_modules/koa/node_modules/koa-compose/index.js:42:32)\\\\n    at /home/julien/travail/git/profiler-server/node_modules/koa/node_modules/koa-compose/index.js:34:12\\\\n    at Application.handleRequest (/home/julien/travail/git/profiler-server/node_modules/koa/lib/application.js:162:12)\\\\n    at Server.handleRequest (/home/julien/travail/git/profiler-server/node_modules/koa/lib/application.js:144:19)\\\\n    at Server.emit (events.js:210:5)\\\\n    at parserOnIncoming (_http_server.js:745:12)\\\\n    at HTTPParser.parserOnHeadersComplete (_http_common.js:115:17)\\"}
+",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;

--- a/test/api/publish.test.js
+++ b/test/api/publish.test.js
@@ -178,7 +178,7 @@ describe('API versioning', () => {
     await req
       .send('a')
       .expect(
-        400,
+        406,
         `The header 'Accept' should have the value application/vnd.firefox-profiler+json; version=1`
       );
   });
@@ -189,14 +189,39 @@ describe('API versioning', () => {
     );
     await req
       .send('a')
-      .expect(406, `Only the API version 1 is supported by this server.`);
+      .expect(
+        406,
+        `The header 'Accept' should have the value application/vnd.firefox-profiler+json; version=1`
+      );
   });
 
   it('returns an error when an accept header is specified without a version at all', async () => {
     const req = getPreconfiguredRequest().accept(ACCEPT_VALUE_MIME);
     await req
       .send('a')
-      .expect(406, `Only the API version 1 is supported by this server.`);
+      .expect(
+        406,
+        `The header 'Accept' should have the value application/vnd.firefox-profiler+json; version=1`
+      );
+  });
+
+  it('returns an error when an accept header is specified with several unacceptable values', async () => {
+    const req = getPreconfiguredRequest().accept(
+      'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'
+    );
+    await req
+      .send('a')
+      .expect(
+        406,
+        `The header 'Accept' should have the value application/vnd.firefox-profiler+json; version=1`
+      );
+  });
+
+  it('accepts the request when there is the expected value amont several values', async () => {
+    const req = getPreconfiguredRequest().accept(
+      `image/webp,${ACCEPT_VALUE_MIME};version=1`
+    );
+    await req.send('a').expect(200, `86f7e437faa5a7fce15d1ddcb9eaeaea377667b8`);
   });
 
   it('accepts the request even if the version is specified with spaces before the parameter', async () => {

--- a/test/api/publish.test.js
+++ b/test/api/publish.test.js
@@ -217,7 +217,7 @@ describe('API versioning', () => {
       );
   });
 
-  it('accepts the request when there is the expected value amont several values', async () => {
+  it('accepts the request when there is the expected value among several values', async () => {
     const req = getPreconfiguredRequest().accept(
       `image/webp,${ACCEPT_VALUE_MIME};version=1`
     );

--- a/test/api/publish.test.js
+++ b/test/api/publish.test.js
@@ -171,6 +171,7 @@ describe('API versioning', () => {
   it('returns an error when no `accept` header is specified', async () => {
     const req = getPreconfiguredRequest();
     await req.send('a').expect(400, `The header 'Accept' is missing.`);
+    expect(process.stdout.write).toMatchSnapshot();
   });
 
   it('returns an error when an invalid `accept` header is specified', async () => {
@@ -181,6 +182,7 @@ describe('API versioning', () => {
         406,
         `The header 'Accept' should have the value application/vnd.firefox-profiler+json; version=1`
       );
+    expect(process.stdout.write).toMatchSnapshot();
   });
 
   it('returns an error when an `accept` header is specified with an unsupported version', async () => {
@@ -193,6 +195,7 @@ describe('API versioning', () => {
         406,
         `The header 'Accept' should have the value application/vnd.firefox-profiler+json; version=1`
       );
+    expect(process.stdout.write).toMatchSnapshot();
   });
 
   it('returns an error when an accept header is specified without a version at all', async () => {
@@ -203,6 +206,7 @@ describe('API versioning', () => {
         406,
         `The header 'Accept' should have the value application/vnd.firefox-profiler+json; version=1`
       );
+    expect(process.stdout.write).toMatchSnapshot();
   });
 
   it('returns an error when an accept header is specified with several unacceptable values', async () => {
@@ -215,6 +219,7 @@ describe('API versioning', () => {
         406,
         `The header 'Accept' should have the value application/vnd.firefox-profiler+json; version=1`
       );
+    expect(process.stdout.write).toMatchSnapshot();
   });
 
   it('accepts the request when there is the expected value among several values', async () => {


### PR DESCRIPTION
This implements a very simple form of versioning.
Once we deploy the server "for real" we'll want to implement an upgrade mechanism as well.