### PR TITLE
Update Dockerfile to build fast-crc32c and install curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,12 @@ RUN set -x \
 RUN mkdir /app \
   && chown app:app /app
 
-# Install git, as we'll need it to generate the version file later on.
+# Install various needed packages:
+# - git, as we'll need it to generate the version file later on.
+# - python, as we need it to build fast-crc32c when installing with yarn later.
+# - build-essential, that installs all build tools for the same reason.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends git \
+  && apt-get install -y --no-install-recommends git python build-essential \
 # and clean the downloaded lists so that they don't increase the layer size.
   && rm -rf /var/lib/apt/lists/*
 
@@ -96,6 +99,12 @@ RUN mkdir /app
 # Note that we don't chown the directory here, on purpose: the "app" user
 # shouldn't own the files so that they're only readable but not writable by this
 # user. The files will be owned by "root".
+
+# Install curl as we'll need it to assert that the server runs properly.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl \
+# and clean the downloaded lists so that they don't increase the layer size.
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
It looks like that recent versions of the debian docker image doesn't include curl by default now. This errors the CI build for new PRs.

While fixing this I also found that `sse4_crc32`, used by `fast-crc32c`, wasn't properly built -- this wasn't erroring because the package is marked as optional. So I fixed that as well.