### PR TITLE
Support CORS preflight requests

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,7 +8,7 @@ import helmet from 'koa-helmet';
 
 import { config } from './config';
 import { getLogger, logLevel } from './log';
-import { routes } from './routes';
+import { configureRoutes } from './routes';
 import { reportTo } from './middlewares';
 
 const log = getLogger('app');
@@ -61,13 +61,7 @@ export function createApp() {
     })
   );
 
-  // Adding the main endpoints for this app.
-  // koa-router exposes 2 middlewares:
-  // - the result of routes() returns the configured routes.
-  // - the result of allowedMethods() configures the OPTIONS verb.
-  const router = routes();
-  app.use(router.routes());
-  app.use(router.allowedMethods());
+  configureRoutes(app);
 
   return app;
 }

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import Router from '@koa/router';
 import cors from '@koa/cors';
 
 import { dockerFlowRoutes } from './dockerflow';
@@ -12,16 +11,51 @@ import { cspReportRoutes } from './cspReport';
 
 import { versioning } from '../middlewares';
 
-export function routes() {
-  const router = new Router();
-  router.use(dockerFlowRoutes().routes());
-  router.use(cspReportRoutes().routes());
+import type Koa from 'koa';
 
-  // Versioning and CORS applies only to API routes, that's why we specify it here.
-  router.use(versioning(1));
-  // We use the default configuration for cors, that is we allow all origins and
-  // all methods.
-  router.use(cors());
-  router.use(publishRoutes().routes());
-  return router;
+/**
+ * This function adds the main endpoints for this app.
+ * We pass the app directly instead of returning a router, because koa-router
+ * won't execute middlewares if there's no matching route (see
+ * https://github.com/koajs/router/issues/44) which is a problem for CORS
+ * preflight requests. So we have to specify the CORS middleware directly on the
+ * app object.
+ *
+ * For each router koa-router exposes 2 middlewares:
+ * - the result of routes() returns the configured routes.
+ * - the result of allowedMethods() configures the OPTIONS verb.
+ * We need to add them both if we want that the OPTIONS verb works properly
+ * (besides CORS).
+ */
+export function configureRoutes(app: Koa) {
+  // Adding the main endpoints for this app.
+  // koa-router exposes 2 middlewares:
+  // - the result of routes() returns the configured routes.
+  // - the result of allowedMethods() configures the OPTIONS verb.
+
+  configureTechnicalRoutes(app);
+
+  // Versioning and CORS applies only to API routes, that's why we specify them
+  // here. Also we specify the CORS middleware before the Versioning middleware
+  // so that versioning doesn't apply to CORS preflight requests.
+
+  // Note we use the default configuration for cors, that is we allow all
+  // origins and all methods.
+  app.use(cors());
+  app.use(versioning(1));
+
+  configureUserFacingRoutes(app);
+}
+
+function configureTechnicalRoutes(app: Koa) {
+  const dockerFlow = dockerFlowRoutes();
+  const cspReport = cspReportRoutes();
+
+  app.use(dockerFlow.routes()).use(dockerFlow.allowedMethods());
+  app.use(cspReport.routes()).use(cspReport.allowedMethods());
+}
+
+function configureUserFacingRoutes(app: Koa) {
+  const publish = publishRoutes();
+  app.use(publish.routes()).use(publish.allowedMethods());
 }

--- a/test/api/publish.test.js
+++ b/test/api/publish.test.js
@@ -168,6 +168,20 @@ describe('publishing endpoints', () => {
     req = checkCorsHeader(req, corsHeaderValue);
     await req;
   });
+
+  it('implements preflight CORS requests', async () => {
+    const corsHeaderValue = 'http://example.org';
+
+    const agent = supertest(createApp().callback());
+    let req = agent
+      .options('/compressed-store')
+      .set('Origin', corsHeaderValue)
+      .set('Access-Control-Request-Method', 'POST')
+      .send();
+
+    req = checkCorsHeader(req, corsHeaderValue);
+    await req;
+  });
 });
 
 describe('API versioning', () => {


### PR DESCRIPTION
CORS preflight requests are sent by the browser in some condition, that are met in the case of the profiler. Especially for us it's because we use a `upload` progress event handler.
A preflight request is a HTTP request using the `OPTIONS` verb and headers `Origin` and `Access-Control-Request-Method`, to the same path as the planned request.

These preflight requests are normally handled by the middleware `koa-cors` automatically when it's set up as expected. This wasn't the case in the previous code, and the result is that the middleware wasn't running for unknown routes (which was the case here because the `OPTIONS` verb matched nothing). This is a behavior from koa-router (https://github.com/koajs/router/issues/44).

The solution I used is attach the middleware directly on the app object. Koa always runs all middleware because it has no concept of route anyway.