### PR TITLE
Change the default port to 5252

### DIFF
--- a/docs-developer/testing-with-command-line-commands.md
+++ b/docs-developer/testing-with-command-line-commands.md
@@ -8,7 +8,7 @@ The following command uploads a file through the server. Curl will automatically
 send a `Content-Length` header using the file size. Of course, don't forget to
 change the path to the file. Note that the character `@` is important!
 ```
-curl -i -X POST --data-binary @/path/to/file -H 'Accept: application/vnd.firefox-profiler+json;version=1.0' localhost:4243/compressed-store
+curl -i -X POST --data-binary @/path/to/file -H 'Accept: application/vnd.firefox-profiler+json;version=1.0' localhost:5252/compressed-store
 ```
 
 The parameter `-i` outputs the response headers as well as the response.
@@ -24,7 +24,7 @@ Sometimes we want to test uploading without the `Content-Length` header. For
 this we'll used the chunked encoding, like this:
 
 ```
-curl -i -X POST --data-binary @/path/to/file -H 'Accept: application/vnd.firefox-profiler+json;version=1.0' -H 'Transfer-Encoding: chunked' localhost:4243/compressed-store
+curl -i -X POST --data-binary @/path/to/file -H 'Accept: application/vnd.firefox-profiler+json;version=1.0' -H 'Transfer-Encoding: chunked' localhost:5252/compressed-store
 ```
 
 Curl will detect that we use the header for chunked encoding and skip sending

--- a/src/config.js
+++ b/src/config.js
@@ -18,7 +18,7 @@ function loadConfig() {
     },
     httpPort: {
       format: 'port',
-      default: 4243,
+      default: 5252,
       // The environment variable's name is required by Dockerflow.
       // see https://github.com/mozilla-services/Dockerflow#containerized-app-requirements
       env: 'PORT',

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -8,13 +8,13 @@ describe('config.js', () => {
   it('returns default values', () => {
     expect(config).toEqual({
       env: 'test',
-      httpPort: 4243,
+      httpPort: 5252,
       gcsBucket: 'profile-store',
       googleAuthenticationFilePath: '',
     });
     expect(loadConfig()).toEqual({
       env: 'test',
-      httpPort: 4243,
+      httpPort: 5252,
       gcsBucket: 'profile-store',
       googleAuthenticationFilePath: '',
     });


### PR DESCRIPTION
I realized that the port 4243 is already used by the development server for the photon example page. So I move this one to 5252 instead.
I chose 5252 over (for example) 4244 because this opens a new "namespace" if we need to have more ports for the server in the future.