### PR TITLE
Turn off require-atomic-updates

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,9 @@ module.exports = {
     'no-constant-condition': ['error', { checkLoops: false }],
     'no-console': ['error', { allow: ['log', 'warn', 'error'] }],
     'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    // This rule gets confused with async functions and setting the
+    // ctx for route responses.
+    'require-atomic-updates': 0,
 
     // possible errors
     'array-callback-return': 'error',

--- a/src/routes/publish.js
+++ b/src/routes/publish.js
@@ -84,10 +84,6 @@ export function publishRoutes() {
 
     const jwtToken = Jwt.generateToken({ profileToken: hash });
 
-    // Eslint thinks that ctx.body is assigned a value that depends on a
-    // previous value of ctx.body, which could be unsafe when using `await`. But
-    // here this is obvously wrong, so let's disable the rule.
-    // eslint-disable-next-line require-atomic-updates
     ctx.body = jwtToken;
   });
 


### PR DESCRIPTION
This rule is getting in the way of a very a common operation with modifying the `ctx`, and it doesn't seem worth it to me.