### PR TITLE
Generate a version that depends on the CircleCI build num

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,8 @@ jobs:
           command: |
             # Use both a version tag depending on the circle's build number
             # and a latest tag that's depending on the branch name.
+            # Please keep the version in sync with the version file generated in
+            # bin/generate-version-file.js.
             IMAGE_VERSION_TAG="0.0.${CIRCLE_BUILD_NUM}"
             IMAGE_LATEST_TAG="${CIRCLE_BRANCH}-latest"
             docker tag profiler-server:dev $IMAGE_NAME:$IMAGE_LATEST_TAG

--- a/bin/generate-version-file.js
+++ b/bin/generate-version-file.js
@@ -47,8 +47,19 @@ function writeVersionFile() {
   const repositoryUrl = packageJson.repository;
 
   const commitHash = getGitCommitHash();
-  const buildUrl = process.env.CIRCLE_BUILD_URL;
-  const version = ''; // TODO: generate a proper version when we're on a tag
+  const buildUrl = process.env.CIRCLE_BUILD_URL || '';
+  // Currently we generate the version from the build url. We're confident this
+  // is always increasing, but for sure this isn't monotonic. In the future we
+  // might want to use a tag instead.
+  const circleBuildNumResult = /\d+$/.exec(buildUrl);
+  if (!circleBuildNumResult) {
+    throw new Error(
+      `We couldn't extract a build num from the build URL, this shouldn't happen. The full build url is: ${buildUrl}.`
+    );
+  }
+  // Please keep it in sync with the version used for the docker image in
+  // .circleci/config.yml.
+  const version = `0.0.${circleBuildNumResult[0]}`;
   const distDir = 'dist';
   const targetName = path.join(distDir, 'version.json');
 


### PR DESCRIPTION
Fixes #53

This is from the "docker" Ci build:
![Capture d’écran de 2020-04-27 19-14-56](https://user-images.githubusercontent.com/454175/80400686-6ef47d80-88bb-11ea-8cb3-e67c303f1943.png)
