### PR TITLE
Add a route for / so that it's easier to test using Mozilla observatory

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -5,6 +5,7 @@
 
 import cors from '@koa/cors';
 
+import { rootRoutes } from './root';
 import { dockerFlowRoutes } from './dockerflow';
 import { publishRoutes } from './publish';
 import { cspReportRoutes } from './cspReport';
@@ -50,9 +51,11 @@ export function configureRoutes(app: Koa) {
 }
 
 function configureTechnicalRoutes(app: Koa) {
+  const root = rootRoutes();
   const dockerFlow = dockerFlowRoutes();
   const cspReport = cspReportRoutes();
 
+  app.use(root.routes()).use(root.allowedMethods());
   app.use(dockerFlow.routes()).use(dockerFlow.allowedMethods());
   app.use(cspReport.routes()).use(cspReport.allowedMethods());
 }

--- a/src/routes/root.js
+++ b/src/routes/root.js
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+// This router implements a very simple route for /, so that we can more easily
+// test the server through tools like the Mozilla Observatory.
+
+import Router from '@koa/router';
+import { getLogger } from '../log';
+
+export function rootRoutes() {
+  const log = getLogger('routes.root');
+  const router = new Router();
+
+  router.get('/', async (ctx) => {
+    log.verbose('/');
+
+    // Let's output a minimal (valid!) HTML document with a link to our repository.
+    ctx.body = `
+      <!doctype html>
+      <html lang='en'>
+      <meta charset='utf-8'>
+      <title>Firefox Profiler Server</title>
+      This is the Firefox Profiler server.
+      See <a href='https://github.com/firefox-devtools/profiler-server'>https://github.com/firefox-devtools/profiler-server</a>
+      for more information.
+    `;
+  });
+
+  return router;
+}

--- a/test/api/root.test.js
+++ b/test/api/root.test.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+import supertest from 'supertest';
+
+import { createApp } from '../../src/app';
+import { checkSecurityHeaders } from './utils/check-security-headers';
+
+describe('/ route', () => {
+  function setup() {
+    const agent = supertest(createApp().callback());
+    return { request: agent.get('/') };
+  }
+
+  it('returns a successful result', async () => {
+    const { request } = setup();
+    await request.expect(200);
+  });
+
+  it('implements security headers', async () => {
+    let { request } = setup();
+    request = checkSecurityHeaders(request);
+    await request;
+  });
+});


### PR DESCRIPTION
Mozilla observatory can only request /. On the server's current version, this errors. And because Koa unsets all headers on errors, all security headers are gone, and Mozilla observatory reports bogus results where we get some default CSP from our reverse proxies.

I think that Koa's behavior is unconditional: https://github.com/koajs/koa/blob/8d52105a34234be9e771ff3b76b43e4e30328943/lib/context.js#L132-L138
Therefore my "fix" here is to allow observatory observe a 200 response.
I would have liked to allow headers to be passed through but sadly this isn't possible. It's not a super big deal either.