### PR TITLE
Add the CSP directive' 'form-action" and increase the HSTS header's max age

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -57,7 +57,8 @@ export function createApp() {
         },
       },
       hsts: {
-        maxAge: 365 * 24 * 60 * 60, // 1 year
+        // 2 years according to https://wiki.mozilla.org/Security/Server_Side_TLS
+        maxAge: 2 * 365 * 24 * 60 * 60,
       },
     })
   );

--- a/src/app.js
+++ b/src/app.js
@@ -50,6 +50,7 @@ export function createApp() {
           defaultSrc: ["'none'"],
           frameAncestors: ["'none'"],
           baseUri: ["'none'"],
+          formAction: ["'self'"],
           // This URI is what the checklist (see link above) suggests.
           reportUri: '/__cspreport__',
           reportTo: 'cspreport',

--- a/test/api/utils/check-security-headers.js
+++ b/test/api/utils/check-security-headers.js
@@ -19,7 +19,7 @@ export function checkSecurityHeaders(request: Test) {
       'Report-To',
       `{"group":"cspreport","max_age":31536000,"endpoints":[{"url":"/__cspreport__"}]}`
     )
-    .expect('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
+    .expect('Strict-Transport-Security', 'max-age=63072000; includeSubDomains')
     .expect('X-DNS-Prefetch-Control', 'off')
     .expect('X-Frame-Options', 'SAMEORIGIN')
     .expect('X-Download-Options', 'noopen')

--- a/test/api/utils/check-security-headers.js
+++ b/test/api/utils/check-security-headers.js
@@ -13,7 +13,7 @@ export function checkSecurityHeaders(request: Test) {
   return request
     .expect(
       'Content-Security-Policy',
-      `default-src 'none'; frame-ancestors 'none'; base-uri 'none'; report-uri /__cspreport__; report-to cspreport`
+      `default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'; report-uri /__cspreport__; report-to cspreport`
     )
     .expect(
       'Report-To',


### PR DESCRIPTION
`form-action` is recommended in Mozilla Observatory, and doesn't get a default value from `default-src`. It's probably not super useful for us but makes no harm.

Mozilla's TLS wiki page recommends a period of 2 years for HSTS (see https://wiki.mozilla.org/Security/Server_Side_TLS).