### PR TITLE
Output more information to the version file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
             yarn docker:run:detached
             # Wait up to 10 seconds that the server is launched.
             timeout 10s sh \<<'EOF'
-            while ! docker exec profiler-server curl --silent --show-error --fail http://localhost:8000/__version__ ; do
+            while ! docker exec profiler-server curl -i --silent --show-error --fail http://localhost:8000/__version__ ; do
               sleep 1
             done
             EOF

--- a/bin/generate-version-file.js
+++ b/bin/generate-version-file.js
@@ -43,10 +43,26 @@ function getGitCommitHash() /*: string */ {
   return hash.trim();
 }
 
+function findLocalBranch() /*: string */ {
+  const branch = execFileSync(
+    'git',
+    ['symbolic-ref', '--short', '-q', 'HEAD'],
+    {
+      encoding: 'utf8',
+    }
+  );
+  // Because execFileSync can return both a string or a buffer depending on the
+  // `encoding` option, Flow isn't happy about calling `trim` on it. But _we_
+  // know that it's a string.
+  // $FlowExpectError
+  return branch.trim();
+}
+
 function writeVersionFile() {
   const repositoryUrl = packageJson.repository;
 
   const commitHash = getGitCommitHash();
+  const branch = findLocalBranch();
   const buildUrl = process.env.CIRCLE_BUILD_URL || '';
   // Currently we generate the version from the build url. We're confident this
   // is always increasing, but for sure this isn't monotonic. In the future we
@@ -68,6 +84,8 @@ function writeVersionFile() {
     version,
     commit: commitHash,
     build: buildUrl,
+    date: new Date().toISOString(),
+    branch,
   };
 
   console.log(`Writing to ${targetName}:`);

--- a/src/routes/dockerflow.js
+++ b/src/routes/dockerflow.js
@@ -27,6 +27,11 @@ export function dockerFlowRoutes() {
     // We try to get the version file in the current working directory.
     const versionFilePath = 'version.json';
     try {
+      const stat = await fs.promises.stat(versionFilePath);
+      ctx.lastModified = stat.mtime;
+
+      // We could try to conditionally answer depending on cache-related headers
+      // in the request but this is a lot of work for this small file.
       const content = await fs.promises.readFile(versionFilePath);
       ctx.body = content;
       ctx.type = 'json';


### PR DESCRIPTION
When I wanted to know what version is deployed on which hostname I realized that the information from the `__version__` file isn't immediate to parse. There's the CircleCI build url that makes it possible to find information about when and what was built, but this requires to go to the build page and this is a slow operation.
Instead outputting the date and the branch will make it very immediate to know what we're dealing with.

I also output a `Last-Modified` header for this file. This should give roughly the same information than the `date` property so maybe this is redundant. Yet the information in the `date` property is a bit more immediate.

I wondered if I should embed this information in the version instead (eg: `0.0.circleci_build_number.datetime_in_YYYYMMDDHHMM_form.branch_name`) but decided this wasn't worth it. Indeed the version is computed both in the dockerfile and the node version script for simplicity, and I didn't want to give up this simplicity.

How the output file looks like:
![image](https://user-images.githubusercontent.com/454175/81284869-f7fb7980-905e-11ea-8954-bd786805496f.png)

The branch here isn't especially useful but I expect it will be `master` or `production` when built out of these branches -- the only ones that are pushed to dockerhub.

When checking if the server in docker is running (see especially the response headers):
![Capture d’écran de 2020-05-07 12-32-04](https://user-images.githubusercontent.com/454175/81284755-d1d5d980-905e-11ea-8236-9a8ea85f829e.png)

You can look at the currently deployed `__version__`: [staging](https://dev.firefoxprofiler.nonprod.cloudops.mozgcp.net/__version__) (that one is a bit old) / [production](https://api.profiler.firefox.com/__version__) (it's currently a version from _master_ actually)