### PR TITLE
Set the X-Frame-Options header to DENY like in CSP

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -60,6 +60,7 @@ export function createApp() {
         // 2 years according to https://wiki.mozilla.org/Security/Server_Side_TLS
         maxAge: 2 * 365 * 24 * 60 * 60,
       },
+      frameguard: { action: 'deny' },
     })
   );
 

--- a/test/api/utils/check-security-headers.js
+++ b/test/api/utils/check-security-headers.js
@@ -21,7 +21,7 @@ export function checkSecurityHeaders(request: Test) {
     )
     .expect('Strict-Transport-Security', 'max-age=63072000; includeSubDomains')
     .expect('X-DNS-Prefetch-Control', 'off')
-    .expect('X-Frame-Options', 'SAMEORIGIN')
+    .expect('X-Frame-Options', 'DENY')
     .expect('X-Download-Options', 'noopen')
     .expect('X-Content-Type-Options', 'nosniff')
     .expect('X-XSS-Protection', '1; mode=block');


### PR DESCRIPTION
Looking at our headers and some security checklist in https://infosec.mozilla.org/guidelines/web_security I realized that the value in this header wasn't synced with the value set in the CSP.
The reason is that I kept the default value for this header while I set the CSP manually.

Additional notes:
* The default value wasn't bad, but setting it to DENY is stricter and more consistent.
* This is only useful for browsers that do not support `frame-ancestors` in the CSP, eg IE11 and old versions of Safari (both desktop and iOS).