### PR TITLE
Add a route for /contribute.json following the security checklist

### DIFF
--- a/src/routes/root.js
+++ b/src/routes/root.js
@@ -28,5 +28,10 @@ export function rootRoutes() {
     `;
   });
 
+  router.get('/contribute.json', async (ctx) => {
+    ctx.status = 301; // Permanent Redirect
+    ctx.redirect('https://profiler.firefox.com/contribute.json');
+  });
+
   return router;
 }

--- a/test/api/root.test.js
+++ b/test/api/root.test.js
@@ -24,3 +24,13 @@ describe('/ route', () => {
     await request;
   });
 });
+
+describe('/contribute.json', () => {
+  it('redirects to the main profiler URL', async () => {
+    const agent = supertest(createApp().callback());
+    await agent
+      .get('/contribute.json')
+      .expect(301)
+      .expect('Location', 'https://profiler.firefox.com/contribute.json');
+  });
+});


### PR DESCRIPTION
This was reported by mozilla observatory and is recommended on https://infosec.mozilla.org/guidelines/web_security for mozilla websites.
I decided to simply redirect to the profiler's version so that we have only one authoritative version.