### PR TITLE
Remove trailing slash from the API endpoint if present

### DIFF
--- a/loadtest/publish.py
+++ b/loadtest/publish.py
@@ -43,6 +43,11 @@ def setup_api_endpoint():
                 'either uncommenting the right line in the file or specifying '
                 'the env variable API_ENDPOINT.'
                 )
+
+    if _API[-1] == '/':
+        # Remove trailing slash if present.
+        _API = _API[:-1]
+
     print(f"We'll run tests against the endpoint {_API}.")
 
 

--- a/loadtest/publish_short_requests.py
+++ b/loadtest/publish_short_requests.py
@@ -44,6 +44,11 @@ def setup_api_endpoint():
                 'either uncommenting the right line in the file or specifying '
                 'the env variable API_ENDPOINT.'
                 )
+
+    if _API[-1] == '/':
+        # Remove trailing slash if present.
+        _API = _API[:-1]
+
     print(f"We'll run tests against the endpoint {_API}.")
 
 

--- a/loadtest/shorten.py
+++ b/loadtest/shorten.py
@@ -44,6 +44,11 @@ def setup_api_endpoint():
                 'either uncommenting the right line in the file or specifying '
                 'the env variable API_ENDPOINT.'
                 )
+
+    if _API[-1] == '/':
+        # Remove trailing slash if present.
+        _API = _API[:-1]
+
     print(f"We'll run tests against the endpoint {_API}.")
 
 


### PR DESCRIPTION
I got bitten by this more than once, enough to add some code to support this :)

Basically before we had to take care that the env variable `API_ENDPOINT` doesn't have `/` at the end.