### PR TITLE
Use latest node v10 in circle ci, and switch to the light images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   node:
     docker:
-      - image: circleci/node:10.15
+      - image: cimg/node:10.21
     environment:
       IMAGE_NAME: mozilla/profiler-server
 

--- a/bin/pre-install.js
+++ b/bin/pre-install.js
@@ -104,9 +104,7 @@ function parseExpectedNodeVersion() {
   const circleConfig = fs.readFileSync('.circleci/config.yml', {
     encoding: 'utf8',
   });
-  const expectedNodeVersion = /image: circleci\/node:([\d.]+)/.exec(
-    circleConfig
-  );
+  const expectedNodeVersion = /image: cimg\/node:([\d.]+)/.exec(circleConfig);
   if (!expectedNodeVersion) {
     throw new Error(
       `Couldn't extract the node version from .circleci/config.yml.`


### PR DESCRIPTION
it looks like that Node v10.15 has some problems with how I use the streams.

Docker always uses latest v10, and tests were working in Docker so I think we're good for the production server.