### PR TITLE
Use node v12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   node:
     docker:
-      - image: cimg/node:10.21
+      - image: cimg/node:12.18
     environment:
       IMAGE_NAME: mozilla/profiler-server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # Setup a container and build the project in it
 # We set up a node 10 running in latest Debian stable called buster, in the
 # "slim" flavor because we don't need the big version.
-FROM node:10-buster-slim AS builder
+FROM node:12-buster-slim AS builder
 
 # Create the user we'll run the build commands with. Its home is configured to
 # be the directory /app. It helps avoiding warnings when running tests and
@@ -87,7 +87,7 @@ RUN du -khs node_modules
 RUN ls -la
 
 # ----- And now, let's build the runtime container -----
-FROM node:10-buster-slim
+FROM node:12-buster-slim
 ENV NODE_ENV="production"
 ENV PORT=8000
 


### PR DESCRIPTION
I use node v12 locally and I haven't seen problems when trying end to end scenarios.

Before deploying to production I'll make sure try the load testing scripts again on the stage deployment.