### PR TITLE
Add a dependabot configuration file to automate dependencies update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every week on monday
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "julienw"
+      - "canova"
+      - "gregtatum"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    # Look for a `Dockerfile` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "julienw"
+      - "canova"
+      - "gregtatum"


### PR DESCRIPTION
I followed the documentation at https://help.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates.

I want to look at how this works here, where the dependencies are reasonably uptodate, before adding it to the profiler frontend repository.