### PR TITLE
Add lockfile-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ workflows:
       - python
       - lint
       - build
+      - yarn_lock
       - flow
       - docker
       - docker-publish:
@@ -99,6 +100,12 @@ jobs:
     steps:
       - checkout-and-dependencies
       - run: yarn flow:ci
+
+  yarn_lock:
+    executor: node
+    steps:
+      - checkout-and-dependencies
+      - run: yarn test-lockfile
 
   build:
     executor: node

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ RUN set -x \
 # we run all test commands separately.
   && yarn flow:ci \
   && yarn lint \
+  && yarn test-lockfile \
   && yarn test \
 # Actually build the project.
   && yarn build:clean \

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "run-p lint-js lint-python",
     "lint-fix": "run-p lint-fix-js",
     "lint-js": "eslint src bin test",
-    "lint-fix-js": "yarn lint --fix",
+    "lint-fix-js": "yarn lint-js --fix",
     "lint-python": "flake8 tools loadtest",
     "preinstall": "node bin/pre-install.js",
     "build:clean": "rimraf dist && mkdirp dist",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "start:prod": "run-s build:clean build serve",
     "test": "jest",
     "test-python": "./tools/test_decode_jwt_payload.py",
-    "test-all": "run-p flow lint test test-python"
+    "test-lockfile": "lockfile-lint --path yarn.lock --allowed-hosts yarn --validate-https",
+    "test-all": "run-p flow lint test test-python test-lockfile"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.3",
@@ -53,6 +54,7 @@
     "flow-typed": "^3.1.0",
     "husky": "^4.2.5",
     "jest": "^26.1.0",
+    "lockfile-lint": "^4.3.7",
     "mkdirp": "^1.0.4",
     "nock": "^13.0.0",
     "nodemon": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1487,6 +1487,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 abab@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
@@ -5055,6 +5060,25 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lockfile-lint-api@^5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/lockfile-lint-api/-/lockfile-lint-api-5.1.6.tgz#74d1e14c0c8270232607eb11e518a92f6f6b1ddd"
+  integrity sha512-liJ1p/NkHbE2Wx5fRw8T1io+x2b2DttVvXpHLm4x7QC8pW3Lc6sHqV4T7cM6rAOs4fF2O9sAt7SEtuN2sX91qA==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    debug "^4.1.1"
+    object-hash "^2.0.1"
+
+lockfile-lint@^4.3.7:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/lockfile-lint/-/lockfile-lint-4.3.7.tgz#68c9d1dc129292cd85a71b2d7f65a9e2fe4333be"
+  integrity sha512-hOHVJyHxtrK6cgYlKoaWveVOCz/w4IXlhmxM+RSWW7f1lA3ENJaRL9eNS9AO0PBKx4P/KMXuker0KzExNDenRg==
+  dependencies:
+    cosmiconfig "^6.0.0"
+    debug "^4.1.1"
+    lockfile-lint-api "^5.1.6"
+    yargs "^15.0.2"
+
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -5530,6 +5554,11 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
+
+object-hash@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.0.3.tgz#d12db044e03cd2ca3d77c0570d87225b02e1e6ea"
+  integrity sha512-JPKn0GMu+Fa3zt3Bmr66JhokJU5BaNBIh4ZeTlaCBzrBsOeXzwcKKAK1tbLiPKgvwmPXsDvvLHoWh5Bm7ofIYg==
 
 object-inspect@^1.7.0:
   version "1.7.0"
@@ -7652,7 +7681,7 @@ yargs-parser@^18.1.3:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs@^15.1.0, yargs@^15.3.1:
+yargs@^15.0.2, yargs@^15.1.0, yargs@^15.3.1:
   version "15.3.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
   integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==


### PR DESCRIPTION
This is a useful check that we already have in the frontend. I find it even more useful now that we have automated tools changing yarn.lock for us :-)

FTR I tried adding other things we have in the frontend:
* alex: this brings too much violations that I think aren't useful in our case.
* license-check: some of our dependencies fail the test because their "license" property uses an invalid value, even though they use the right license. I filed PR here and there (including in license-check itself to accept these values) so that hopefully we could add it in the future.