### PR TITLE
Add information about the new staging server

### DIFF
--- a/docs-developer/deployment.md
+++ b/docs-developer/deployment.md
@@ -3,7 +3,12 @@
 ## Servers
 
 * The `master` branch deploys to https://dev.firefoxprofiler.nonprod.cloudops.mozgcp.net.
-* The `production` branch deploys to https://api.profiler.firefox.com.
+* The `production` branch deploys to 2 servers:
+  * configured with a sandbox storage: https://stage.firefoxprofiler.nonprod.cloudops.mozgcp.net.
+  * configured with the production storage: https://api.profiler.firefox.com.
+
+The "stage" server is useful to run load testing runs and compare results with
+the current development server.
 
 ## Environment
 

--- a/loadtest/publish.py
+++ b/loadtest/publish.py
@@ -24,6 +24,9 @@ _API = None
 # This is the staging server.
 # _API = 'https://dev.firefoxprofiler.nonprod.cloudops.mozgcp.net'
 
+# This is a production code deployment configured with a sandbox storage.
+# _API = 'https://stage.firefoxprofiler.nonprod.cloudops.mozgcp.net'
+
 # This is the various file sizes we'll generate in the global setup.
 _FILE_SIZES = (512, 1024, 5 * 1024, 20 * 1024)
 

--- a/loadtest/publish_short_requests.py
+++ b/loadtest/publish_short_requests.py
@@ -25,6 +25,9 @@ _API = None
 # This is the staging server.
 # _API = 'https://dev.firefoxprofiler.nonprod.cloudops.mozgcp.net'
 
+# This is a production code deployment configured with a sandbox storage.
+# _API = 'https://stage.firefoxprofiler.nonprod.cloudops.mozgcp.net'
+
 # This is the various file sizes we'll generate in the global setup.
 _FILE_SIZES = (1, 10, 50)
 

--- a/loadtest/shorten.py
+++ b/loadtest/shorten.py
@@ -23,6 +23,9 @@ _API = None
 # This is the staging server.
 # _API = 'https://dev.firefoxprofiler.nonprod.cloudops.mozgcp.net'
 
+# This is a production code deployment configured with a sandbox storage.
+# _API = 'https://stage.firefoxprofiler.nonprod.cloudops.mozgcp.net'
+
 # This is a profile URL that we want to shorten. By using always the same one
 # bitly won't create a new one.
 _LONG_URL = 'https://profiler.firefox.com/public/00cbf186938d721bf168ad036930c09cf641eb40/calltree/?globalTrackOrder=0&invertCallstack&localTrackOrderByPid=5898-0-1~&search=const&thread=0&v=4'  # noqa: E501


### PR DESCRIPTION
This adds some more documentation about the new server. The goal for this new server is that we can run full tests on it, this makes it easy to compare to the dev server by running the same big tests without disrupting the production server, and assess performance improvements / problems with new code.