### PR TITLE
Add the error reason to the FlowExpectedError comments, because newer…

### DIFF
--- a/bin/generate-version-file.js
+++ b/bin/generate-version-file.js
@@ -39,7 +39,7 @@ function getGitCommitHash() /*: string */ {
   // Because execFileSync can return both a string or a buffer depending on the
   // `encoding` option, Flow isn't happy about calling `trim` on it. But _we_
   // know that it's a string.
-  // $FlowExpectedError
+  // $FlowExpectedError[prop-missing]
   return hash.trim();
 }
 
@@ -54,7 +54,7 @@ function findLocalBranch() /*: string */ {
   // Because execFileSync can return both a string or a buffer depending on the
   // `encoding` option, Flow isn't happy about calling `trim` on it. But _we_
   // know that it's a string.
-  // $FlowExpectedError
+  // $FlowExpectedError[prop-missing]
   return branch.trim();
 }
 


### PR DESCRIPTION
… versions of Flow warn about this

This fixes [the Flow error](https://circleci.com/gh/firefox-devtools/profiler-server/2487) in https://github.com/firefox-devtools/profiler-server/pull/150. Starting Flow 0.132, Flow generates warnings to suggest adding the underlying reason of $FlowExpectedError comments. But we configure our Flow so that warnings error our check, because we want that old $FlowExpectedError that don't match anymore be removed. So... we have to add these reasons too :-)