### PR TITLE
Upgrade node to the latest versions in the tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   node:
     docker:
-      - image: cimg/node:12.18
+      - image: cimg/node:12.20
     environment:
       IMAGE_NAME: mozilla/profiler-server
 


### PR DESCRIPTION
This is a very simple patch to get latest version of v12 for tests. The server is already using the latest and greatest version automatically because we're not specifying the minor version, only the major version.