### PR TITLE
Add an integration test to be run locally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ executors:
     docker:
       - image: cimg/python:3.10-node
 
+orbs:
+  shellcheck: circleci/shellcheck@3.0.0
+
 commands:
   checkout-and-dependencies:
     description: "Checkout and install dependencies, managing a cache"
@@ -46,6 +49,8 @@ workflows:
       - yarn_lock
       - flow
       - license-check
+      - shellcheck/check:
+          name: "Shellcheck"
       - docker
       - docker-publish:
           requires:

--- a/test/integration/test-publish-and-delete.sh
+++ b/test/integration/test-publish-and-delete.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# Prerequisites:
+# * installation steps in loadtest/README.md have been followed.
+# * dependencies have been installed with `yarn`.
+# * the server is locally configured with a .env pointing to an existing google
+#   storage bucket with the appropriate permissions.
+
+# Exit on error
+set -e
+
+# Display all commands (for debugging)
+#set -x
+
+### First, let's check the prerequisites.
+if [ ! -d loadtest/venv ] ; then
+  echo "The python virtualenv seems to be missing." 1>&2
+  echo "Please run the instructions in the install section of loadtest/README.md and run this script again." 1>&2
+  exit 1
+fi
+
+### And now, let's move on with the actual tasks.
+
+echo ">>> Starting the server."
+node_modules/.bin/babel-node src/index.js &
+server_pid=$!
+
+cleanup() {
+  echo ">>> Stopping the server."
+  # babel-node doesn't forward the TERM signal, see https://github.com/babel/babel/pull/13784
+  kill -INT $server_pid
+}
+
+# Execute the cleanup function when exiting (either normally or when
+# encountering an error thanks to `set -e` above).
+trap cleanup EXIT
+
+echo ">>> Waiting that the server starts."
+while ! curl -i --silent -S --show-error --fail http://localhost:5252/__lbheartbeat__  1> /dev/null ; do
+  sleep 1
+done
+
+echo ">>> Running a molotov scenario"
+(
+  cd loadtest
+  # shellcheck disable=SC1091
+  . venv/bin/activate
+  API_ENDPOINT=http://localhost:5252 molotov --single-mode publish_and_delete -r 1 --fail 1 publish.py
+)


### PR DESCRIPTION
I've been using this script regularly, and I believe it could be good to put it in out codebase.

We can't run it easily from CI, because currently this needs a properly configured `.env`. But ideally in the future we could configure a google storage for the CI and use it for the script.