### PR TITLE
Query the actual port that has been used for listening to input connections

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const log = getLogger('index');
 const app = createApp();
 
 const server = app.listen(config.httpPort);
-log.info('server_started', { port: config.httpPort });
+log.info('server_started', { port: server.address().port });
 
 function gracefulExit() {
   log.info('server_exit', 'Received exit request. Closing app...');


### PR DESCRIPTION
Previously we were showing the configured port. The difference is when we use a port of 0, which makes nodes choose an available port automatically. This will come up handy for the integration test in #251.

You can test locally by running:
```
PORT=0 yarn start
```

Previously:
```
INFO FirefoxProfiler.index.server_started: {"port":0}
```

Now:
```
INFO FirefoxProfiler.index.server_started: {"port":43385}
```