### PR TITLE
Stop calling 'end' from inside the json checker

### DIFF
--- a/src/utils/streams.js
+++ b/src/utils/streams.js
@@ -166,11 +166,9 @@ export class CheapJsonChecker extends Writable {
         case 'found':
           this.log.verbose('json-found', 'This stream looks like a JSON.');
           this.checkEnded = true;
+          // This stream did what it's for. Let's emit an event to specify it.
+          this.emit('profiler:checkEnded');
           callback();
-          // This stream did what it's for so let's clean it up.
-          // Calling end will also stop any piping gracefully.
-          // Using nextTick allows some bufferred write to finish.
-          process.nextTick(() => this.end());
           return;
         case 'error':
           this.log.verbose(
@@ -185,7 +183,7 @@ export class CheapJsonChecker extends Writable {
     }
   }
 
-  // This is called when all the data has been given to _transform and the
+  // This is called when all the data has been given to _write and the
   // stream is ended.
   _final(callback: (error?: Error) => void) {
     this.log.trace('_final()');

--- a/test/unit/streams.test.js
+++ b/test/unit/streams.test.js
@@ -5,6 +5,8 @@
 import util from 'util';
 import Stream, { PassThrough } from 'stream';
 import { gzipSync } from 'zlib';
+// $FlowExpectedError[missing-export] Flow doesn't know about events.once, that's too bad.
+import { once } from 'events';
 
 import {
   Concatenator,
@@ -16,39 +18,48 @@ import {
 // how we'll use these streams in the app code.
 const pipeline = util.promisify(Stream.pipeline);
 const nextTick = util.promisify(process.nextTick);
-describe('EarlyContentChecker', () => {
+const END_EVENT_NAME = 'profiler:checkEnded';
+
+describe('CheapJsonChecker', () => {
   it('accepts normal content', async () => {
     const fixture = '{ "foo": "bar" }';
     const checker = new CheapJsonChecker();
     const input = new PassThrough();
+    const endPromise = once(checker, END_EVENT_NAME);
     input.write(fixture.slice(0, 3));
     input.end(fixture.slice(3));
     await expect(pipeline(input, checker)).resolves.toBe(undefined);
+    expect(endPromise).resolves.toEqual([]);
   });
 
   it('accepts content with some space at the start', async () => {
     const fixture = '                               { "foo": "bar" }';
     const checker = new CheapJsonChecker();
     const input = new PassThrough();
+    const endPromise = once(checker, END_EVENT_NAME);
     input.write(fixture.slice(0, 3));
     input.end(fixture.slice(3));
     await expect(pipeline(input, checker)).resolves.toBe(undefined);
+    expect(endPromise).resolves.toEqual([]);
   });
 
   it(`rejects if there's only space in the content`, async () => {
     const fixture = '                           ';
     const checker = new CheapJsonChecker();
     const input = new PassThrough();
+    const endPromise = once(checker, END_EVENT_NAME);
     input.write(fixture);
     input.end();
     await expect(pipeline(input, checker)).rejects.toThrow(
       "The payload isn't a JSON object."
     );
+    expect(endPromise).rejects.toThrow("The payload isn't a JSON object.");
   });
 
   it('rejects if required content is missing', async () => {
     const fixture = 'bad content';
     const checker = new CheapJsonChecker();
+    const endPromise = once(checker, END_EVENT_NAME);
     const input = new PassThrough();
     input.write(fixture);
     // Note: we don't call .end() so that we test that we can find a bad content
@@ -56,26 +67,31 @@ describe('EarlyContentChecker', () => {
     await expect(pipeline(input, checker)).rejects.toThrow(
       "The payload isn't a JSON object."
     );
+    expect(endPromise).rejects.toThrow("The payload isn't a JSON object.");
   });
 
   it('supports unicode characters too', async () => {
     const fixture = '{ "éàçâ": "bar" }';
     const checker = new CheapJsonChecker();
     const input = new PassThrough();
+    const endPromise = once(checker, END_EVENT_NAME);
     input.write(fixture.slice(0, 3)); // This should cut in the middle of a unicode character
     input.end(fixture.slice(3));
     await expect(pipeline(input, checker)).resolves.toBe(undefined);
+    expect(endPromise).resolves.toEqual([]);
   });
 
   it('supports long-running operations', async () => {
     const fixture = '{ "foo": "bar" }';
     const checker = new CheapJsonChecker();
     const input = new PassThrough();
+    const endPromise = once(checker, END_EVENT_NAME);
     const pipelinePromise = pipeline(input, checker);
     input.write(fixture.slice(0, 3));
     await nextTick();
     input.end(fixture.slice(3));
     await expect(pipelinePromise).resolves.toBe(undefined);
+    expect(endPromise).resolves.toEqual([]);
   });
 });
 


### PR DESCRIPTION
This is a requirement for #173.

This makes this stream less uncommon, and as a result, less likely to break when node is upgraded.
Instead we emit a custom event and destroy the stream from the user side.

I checked that with this change the tests don't break for node v14 and v16 anymore.
The main code wasn't broken in node v14 and v16 but after having studied node's stream code for a few days I believe the previous way was a bit fragile and could bring unexpected problems. I think this new code is more solid.

Tell me what you think!

I tested this by running locally the server and running the molotov scripts on it. I tested a local version of the profiler frontend pointing to this local server, and I also tested manually pushing an image (compressed to gzip) which was correctly rejected.