### PR TITLE
Remove one reference to a bad ansi-regex

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1638,11 +1638,11 @@ ajv@^8.0.1:
     uri-js "^4.2.2"
 
 ansi-align@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"
-  integrity sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.1.tgz#0cdf12e111ace773a86e9a1fad1225c43cb19a59"
+  integrity sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==
   dependencies:
-    string-width "^3.0.0"
+    string-width "^4.1.0"
 
 ansi-colors@^3.2.1:
   version "3.2.4"


### PR DESCRIPTION
I followed the result of `yarn audit` locally. This change is a fix for this dependency chain:
nodemon > update-notifier > boxen > ansi-align > string-width > strip-ansi > ansi-regex    

We miss another reference because of a dependency from flow-typed. I filed https://github.com/flow-typed/flow-typed/issues/4151 there and will follow along their progress.