### PR TITLE
Update molotov to 2.4 to fix the dependency issues on loadtest

### DIFF
--- a/loadtest/requirements.txt
+++ b/loadtest/requirements.txt
@@ -1,1 +1,1 @@
-molotov==2.0
+molotov==2.4


### PR DESCRIPTION
Previous versions were using a dependency that is dead which is
aiomeasures. It was failing to find that dependency and failing to
install molotov overall. 2.4 removes that dependency.