### PR TITLE
Make fast-crc32c an optional dependency for M1 chips

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ cd profiler-server
 yarn install
 ```
 
+#### For Apple M1 chips
+
+There is an optional dependency that doesn't support M1 chips. Run `yarn install --ignore-optional` instead to skip installing it.
+
 ### Configure the server
 
 Then you'll need to configure the server. We use environment variables for this,

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "content-type": "^1.0.4",
     "convict": "^6.2.1",
     "dotenv": "^16.0.0",
-    "fast-crc32c": "^2.0.0",
     "jsonwebtoken": "^8.5.1",
     "koa": "^2.13.4",
     "koa-helmet": "^6.1.0",
@@ -90,5 +89,8 @@
     "koa-logger": "^3.2.1",
     "mozlog": "^3.0.2",
     "node-fetch": "^2.6.7"
+  },
+  "optionalDependencies": {
+    "fast-crc32c": "^2.0.0"
   }
 }


### PR DESCRIPTION
This PR both changes the `fast-crc32c` dependency to be optional and documents this in our README.md file so people who use M1 chips can install the dependencies properly.