### PR TITLE
Appease the newer version of flake8

### DIFF
--- a/loadtest/publish.py
+++ b/loadtest/publish.py
@@ -146,7 +146,8 @@ def jwt_base64_decode(payload):
 
 
 def payload_from_raw_data(raw_data):
-    """Returns a data suitable to publish, that's accepted by the profiler server.
+    """
+    Returns a data suitable to publish, that's accepted by the profiler server.
 
     This concatenates separate pre-created gzip-compressed chunks, because we
     want that we do as less work as possible at runtime. Here at runtime we

--- a/loadtest/publish_short_requests.py
+++ b/loadtest/publish_short_requests.py
@@ -147,7 +147,8 @@ def jwt_base64_decode(payload):
 
 
 def payload_from_raw_data(raw_data):
-    """Returns a data suitable to publish, that's accepted by the profiler server.
+    """
+    Returns a data suitable to publish, that's accepted by the profiler server.
 
     This concatenates separate pre-created gzip-compressed chunks, because we
     want that we do as less work as possible at runtime. Here at runtime we


### PR DESCRIPTION
The old version of flake8 seemed to miss this line.

The error was:
```
$ flake8 tools loadtest
loadtest/publish.py:149:80: E501 line too long (82 > 79 characters)
loadtest/publish_short_requests.py:150:80: E501 line too long (82 > 79 characters)
```