### PR TITLE
Accept fetch requests only from designated origins

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -43,7 +43,23 @@ export function configureRoutes(app: Koa) {
 
   // Note we use the default configuration for cors, that is we allow all
   // origins and all methods.
-  app.use(cors());
+  app.use(
+    cors({
+      origin: (ctx) => {
+        const origin = ctx.get('Origin');
+        if (
+          origin.endsWith('perf-html.netlify.app') ||
+          origin.endsWith('localhost:4242')
+        ) {
+          // Allow deploy previews and local development server.
+          return origin;
+        }
+        // Otherwise allow only the profiler UI
+        // Please file a bug if you'd like to upload from another origin.
+        return 'https://profiler.firefox.com';
+      },
+    })
+  );
   app.use(versioning(1));
 
   configureUserFacingRoutes(app);

--- a/test/api/profile.test.ts
+++ b/test/api/profile.test.ts
@@ -205,7 +205,7 @@ describe('DELETE /profile', () => {
     const { agent, acceptHeader, postProfileToCompressedStore } = setup();
     const { profileToken, jwtToken } = await postProfileToCompressedStore();
 
-    const corsHeaderValue = 'http://example.org';
+    const corsHeaderValue = 'https://profiler.firefox.com';
 
     let request = agent
       .delete(`/profile/${profileToken}`)

--- a/test/api/publish.test.ts
+++ b/test/api/publish.test.ts
@@ -190,18 +190,43 @@ describe('publishing endpoints', () => {
   });
 
   it('implements security headers', async () => {
-    const corsHeaderValue = 'http://example.org';
+    // It returns the cors header for profiler.firefox.com for all origins.
     let req = getPreconfiguredRequest()
-      .set('Origin', corsHeaderValue)
+      .set('Origin', 'https://profiler.firefox.com')
       .send(BASIC_PAYLOAD)
       .expect(200);
     req = checkSecurityHeaders(req);
-    req = checkCorsHeader(req, corsHeaderValue);
+    req = checkCorsHeader(req, 'https://profiler.firefox.com');
+    await req;
+
+    req = getPreconfiguredRequest()
+      // No origin
+      .send(BASIC_PAYLOAD)
+      .expect(200);
+    req = checkCorsHeader(req, 'https://profiler.firefox.com');
+    await req;
+
+    // Except localhost and deploy previews
+    req = getPreconfiguredRequest()
+      .set('Origin', 'http://localhost:4242')
+      .send(BASIC_PAYLOAD)
+      .expect(200);
+    req = checkCorsHeader(req, 'http://localhost:4242');
+    await req;
+
+    req = getPreconfiguredRequest()
+      .set('Origin', 'https://deploy-preview-4682--perf-html.netlify.app')
+      .send(BASIC_PAYLOAD)
+      .expect(200);
+    req = checkCorsHeader(
+      req,
+      'https://deploy-preview-4682--perf-html.netlify.app'
+    );
     await req;
   });
 
   it('implements preflight CORS requests', async () => {
-    const corsHeaderValue = 'http://example.org';
+    const corsHeaderValue = 'https://profiler.firefox.com';
 
     const agent = supertest(createApp().callback());
     let req = agent

--- a/test/api/shorten.test.ts
+++ b/test/api/shorten.test.ts
@@ -131,7 +131,7 @@ describe('shorten url', () => {
   it('implements security headers', async () => {
     const longUrl = 'https://profiler.firefox.com/public/FAKEHASH/calltree';
     const shortUrl = 'https://share.firefox.dev/BITLYHASH';
-    const corsHeaderValue = 'http://example.org';
+    const corsHeaderValue = 'https://profiler.firefox.com';
 
     let { request } = setup({ longUrl, shortUrl });
     request
@@ -268,7 +268,7 @@ describe('expand url', () => {
   it('implements security headers', async () => {
     const longUrl = 'https://profiler.firefox.com/public/FAKEHASH/calltree';
     const shortUrl = 'https://share.firefox.dev/BITLYHASH';
-    const corsHeaderValue = 'http://example.org';
+    const corsHeaderValue = 'https://profiler.firefox.com';
 
     let { request } = setup({ longUrl, shortUrl });
     request


### PR DESCRIPTION
This PRs changes our implementation of CORS to accept requests only from some origins:
* profiler.firefox.com of course
* all deploy previews
* the development server on localhost:4242

This affects shortening of links, publishing and deleting.

Hey @canova @mstange, how do you feel about this change?