### PR TITLE
Update debian to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,10 @@
 # instead of the default. See docs-developer/docker.md for more information.
 
 # Setup a container and build the project in it
-# We set up a node 18 running in latest Debian stable called bullseye, in the
+# We set up a node 18 running in latest Debian stable called bookworm, in the
 # "slim" flavor because we don't need the big version.
-FROM node:18-bullseye-slim AS builder
+# NOTE: if you update the image here, don't forget to update it below as well.
+FROM node:18-bookworm-slim AS builder
 
 # Create the user we'll run the build commands with. Its home is configured to
 # be the directory /app. It helps avoiding warnings when running tests and
@@ -86,7 +87,7 @@ RUN du -khs node_modules
 RUN ls -la
 
 # ----- And now, let's build the runtime container -----
-FROM node:18-bullseye-slim
+FROM node:18-bookworm-slim
 ENV NODE_ENV="production"
 ENV PORT=8000
 

--- a/docs-developer/docker.md
+++ b/docs-developer/docker.md
@@ -35,7 +35,8 @@ Especially the environment variable `JWT_SECRET` needs to be set.
 
 If the variable `GCS_AUTHENTICATION_PATH` is set the pointed file will be
 mounted to the docker instance as well, so that Google Storage authentication
-works.
+works. Make sure to change its group to "10001" so that the docker image can
+access it.
 
 The app should listen on port 8000. The container is named `profiler-server`.
 

--- a/loadtest/Dockerfile
+++ b/loadtest/Dockerfile
@@ -11,9 +11,9 @@
 # runtime with the env variable API_ENDPOINT.
 
 # Setup a container and download the project in it
-# We set up a python 3 running in latest Debian stable called bullseye, in the
+# We set up a python 3 running in latest Debian stable called bookworm, in the
 # "slim" flavor because we don't need the big version.
-FROM python:3-slim-bullseye
+FROM python:3-slim-bookworm
 
 # Create the user we'll run the build commands with. Its home is configured to
 # be the directory /app. It helps avoiding warnings when running tests and
@@ -28,8 +28,9 @@ RUN mkdir /app \
 
 # Install various needed packages:
 # - git, as we'll need it to pull molotov
+# - build tools, as this is needed for some Python packages
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends git \
+  && apt-get install -y --no-install-recommends git build-essential \
 # and clean the downloaded lists so that they don't increase the layer size.
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This updates to the latest Debian stable (out for ~6 months now).

I built locally both docker files, and also ran both docker images locally.

After merging to the master branch, I'll run the load test on the deployed docker, as a sanity check. I don't expect a big change.