### PR TITLE
Update to node v22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   node:
     docker:
-      - image: cimg/node:18.19
+      - image: cimg/node:22.14
     environment:
       IMAGE_NAME: mozilla/profiler-server
 
@@ -12,7 +12,7 @@ executors:
   # preinstalled, but otherwise the exact version for node isn't important.
   python:
     docker:
-      - image: cimg/python:3.11-node
+      - image: cimg/python:3.13-node
 
 orbs:
   shellcheck: circleci/shellcheck@3.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,10 @@
 # instead of the default. See docs-developer/docker.md for more information.
 
 # Setup a container and build the project in it
-# We set up a node 18 running in latest Debian stable called bookworm, in the
+# We set up a node 22 running in latest Debian stable called bookworm, in the
 # "slim" flavor because we don't need the big version.
 # NOTE: if you update the image here, don't forget to update it below as well.
-FROM node:18-bookworm-slim AS builder
+FROM node:22-bookworm-slim AS builder
 
 # Create the user we'll run the build commands with. Its home is configured to
 # be the directory /app. It helps avoiding warnings when running tests and
@@ -87,7 +87,7 @@ RUN du -khs node_modules
 RUN ls -la
 
 # ----- And now, let's build the runtime container -----
-FROM node:18-bookworm-slim
+FROM node:22-bookworm-slim
 ENV NODE_ENV="production"
 ENV PORT=8000
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,18 @@
   "author": "Mozilla",
   "license": "MPL-2.0",
   "private": true,
+  "engines": {
+    "node": ">= 22 < 23"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">= 22 < 23"
+    },
+    "packageManager": {
+      "name": "yarn"
+    }
+  },
   "scripts": {
     "license-check": "devtools-license-check",
     "lint": "run-p lint-js lint-python prettier-run",


### PR DESCRIPTION
Everything seems to work just fine after the update.

There is a warning when running the server:
```
(node:299536) [DEP0048] DeprecationWarning: The `util.isError` API is deprecated. Please use `ObjectPrototypeToString(e) === "[object Error]" || e instanceof Error` instead.
```
I traced that down to https://github.com/seanmonstar/intel/pull/58 (pull request opened by @soulgalore well-known by us :-) ), where `intel` is a dependency for https://github.com/mozilla/mozlog. Both these libraries do not appear well maintained at the moment. We could maintain mozlog ourselves and possibly fork `intel`, but that's not really needed at the moment because everything still works, and I don't imagine nodejs removing that API really soon.

I'll run some loadtesting on the staging server after the merge.