### PR TITLE
Update the load testing script to make it shorter

### DIFF
--- a/docs-developer/deployment.md
+++ b/docs-developer/deployment.md
@@ -13,7 +13,7 @@ the current development server. The helper script
 
 Note that the two "non production" servers run on the same cluster and are
 configured to not auto-scale, so be careful to test them separately. Using the
-script, typical results are between 110000 and 130000 successful requests at the
+script, typical results are around 60000 successful requests at the
 full throughput for these non prod environments.
 
 ## Environment

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -4,6 +4,9 @@ This documentation explains how to run the load tests for the profiler server.
 We'll see how to install the main dependency [molotov](https://molotov.readthedocs.io/en/latest/)
 and then how to use it to run the tests.
 
+See also the script in `tools/load-testing-before-deployment.sh` that runs this
+automatically.
+
 ## Install dependencies
 
 The library we use depends on Python 3.

--- a/tools/load-testing-before-deployment.sh
+++ b/tools/load-testing-before-deployment.sh
@@ -39,16 +39,16 @@ run_tests() (
 
   echo ">>> Ramp up"
   echo "Do not pay attention to the results for this run."
-  molotov -w 200 -d 300 --ramp-up 60 publish_short_requests.py
+  molotov -w 200 -d 150 --ramp-up 60 publish_short_requests.py
 
-  echo ">>> Run a load test operation: 200 clients during 5 minutes (1/3)"
-  molotov -w 200 -d 300 publish_short_requests.py
+  echo ">>> Run a load test operation: 200 clients during 2.5 minutes (1/3)"
+  molotov -w 200 -d 150 publish_short_requests.py
 
-  echo ">>> Run a load test operation: 200 clients during 5 minutes (2/3)"
-  molotov -w 200 -d 300 publish_short_requests.py
+  echo ">>> Run a load test operation: 200 clients during 2.5 minutes (2/3)"
+  molotov -w 200 -d 150 publish_short_requests.py
 
-  echo ">>> Run a load test operation: 200 clients during 5 minutes (3/3)"
-  molotov -w 200 -d 300 publish_short_requests.py
+  echo ">>> Run a load test operation: 200 clients during 2.5 minutes (3/3)"
+  molotov -w 200 -d 150 publish_short_requests.py
 )
 
 echo ">>>>>>>>>>> Stage Server (production code in a sandbox environment) <<<<<<<<<<<<<"


### PR DESCRIPTION
Last time we looked at it with @canova, I remembered we thought that the 5 minutes (an arbitrary duration I picked when I initially worked on that) were too long. So I reduced this to 2:30 minutes instead. This makes the duration for the entire script about 15 minutes instead of 30 minutes.

Please tell me what you think @canova !
